### PR TITLE
Enhance lore and table details

### DIFF
--- a/lore_and_tables_improvements_research.md
+++ b/lore_and_tables_improvements_research.md
@@ -1,0 +1,541 @@
+# Research: Improvements to Existing Lore and Tables
+## Hexy - Dying Lands Hexcrawl Generator
+
+**Research Date:** January 2025  
+**Project:** Hexy - Mörk Borg Hexcrawl Generator  
+**Focus:** Enhancing existing lore database and content tables
+
+---
+
+## 📊 Current System Analysis
+
+### Existing Strengths
+- **Comprehensive lore database** with 6 major cities, regional biases, and hardcoded locations
+- **Extensive content tables** with bilingual support (EN/PT)
+- **Modular table system** organized by categories (dungeon, bestiary, loot, etc.)
+- **Terrain-aware generation** with biome-specific content
+- **Strong Mörk Borg atmosphere** maintained throughout
+
+### Identified Gaps
+- **Limited post-2020 official content** integration
+- **Static faction relationships** without dynamic evolution
+- **Basic interconnected storylines** between hexes
+- **Limited weather and seasonal effects**
+- **Minimal third-party supplement integration**
+
+---
+
+## 🏰 Lore Database Improvements
+
+### 1. Official Content Integration
+
+#### New Official Entities from Recent Supplements
+Based on recent Mörk Borg releases like "Ikhon" (2024):
+
+**Forgotten Gods (Profane Profound)**
+```python
+'forgotten_gods': {
+    'bilkherd': {
+        'name': 'The Bilkherd',
+        'name_pt': 'O Bilkherd', 
+        'domain': 'Cattle and Sacrifice',
+        'influence_regions': ['south', 'central'],
+        'followers': 'Cattle herders, desperate farmers',
+        'gifts': ['Enhanced livestock', 'Milk that heals', 'Beast communication'],
+        'punishments': ['Diseased cattle', 'Barren fields', 'Stampedes'],
+        'shrine_locations': ['Hidden in barns', 'Stone circles in pastures']
+    },
+    'becklure': {
+        'name': 'The Becklure',
+        'name_pt': 'O Becklure',
+        'domain': 'Water and Drowning',
+        'influence_regions': ['coast', 'swamp'],
+        'followers': 'Fishermen, smugglers, the desperate',
+        'gifts': ['Safe passage over water', 'Finding drowned treasures', 'Water breathing'],
+        'punishments': ['Drowning visions', 'Cursed catches', 'Phantom undertows'],
+        'shrine_locations': ['Submerged caves', 'Abandoned lighthouses']
+    }
+    # ... additional forgotten gods
+}
+```
+
+#### Enhanced City Details
+Expand existing cities with recent lore developments:
+
+**Galgenbeck Expansions**
+- **Ministry of Wealth & Taxes** (from "Death and Taxes" supplement)
+- **Guild of the Utmost Eager Day Laborers**
+- **House of Binding Contracts** (demon-infested financial institution)
+- **Cult of the Golden Tongue** presence
+
+**New Settlement Types**
+- **Plague Quarantine Camps** - Temporary settlements around diseased areas
+- **Crusader Staging Grounds** - Military encampments preparing for expeditions
+- **Heretic Hideouts** - Secret communities of religious outcasts
+
+### 2. Dynamic Faction Evolution
+
+#### Enhanced Faction System
+```python
+'faction_relationships': {
+    'nechrubel_cult': {
+        'allies': ['plague_bearers', 'shadow_king_followers'],
+        'enemies': ['heretical_priests', 'forest_witches'],
+        'neutral': ['death_merchants'],
+        'relationship_changes': {
+            'seasonal': 'Stronger during calendar miseries',
+            'proximity': 'More active near major cities',
+            'player_actions': 'Responds to party interference'
+        }
+    }
+}
+
+'faction_activities': {
+    'nechrubel_cult': {
+        'recruitment_drives': ['Desperate settlements', 'Plague survivors'],
+        'ritual_sites': ['Ancient stone circles', 'Desecrated churches'],
+        'resources_sought': ['Human sacrifices', 'Forbidden knowledge', 'Calendar fragments'],
+        'monthly_events': [
+            'Mass ritual at new moon',
+            'Recruitment in suffering communities', 
+            'Artifact seeking expeditions'
+        ]
+    }
+}
+```
+
+#### Faction Territorial Control
+```python
+'territorial_influence': {
+    'hex_ranges': {
+        'nechrubel_cult': ['1215-1315', '0510-0610'],  # Areas around Galgenbeck
+        'forest_witches': ['0405-0510', '0608-0712'],  # Sarkash Forest region
+        'plague_bearers': ['0615-0720', '1820-2025']   # Western and southern areas
+    },
+    'influence_strength': {
+        'dominant': 0.8,    # Faction controls 80% of encounters
+        'strong': 0.6,      # 60% control
+        'present': 0.3,     # 30% control
+        'absent': 0.0       # No faction presence
+    }
+}
+```
+
+### 3. Regional Lore Expansions
+
+#### Enhanced Regional Themes
+**Northern Regions (Bergen Chrypt Area)**
+- **The Bone Crown Mysteries** - Ancient burial kingdoms
+- **Ice Witch Covens** - Frozen magic practitioners
+- **Troll-Human Hybrid Communities** - From recent supplements
+- **Abandoned Crusader Camps** - Failed expeditions to the Valley
+
+**Western Coast (Pyre-Chrypt Region)**
+- **Plague Ship Graveyards** - Diseased vessels run aground
+- **Storm Cult Settlements** - Weather-worshipping communities
+- **Smuggler Trade Routes** - Black market pathways
+- **Quarantine Islands** - Isolated plague colonies
+
+#### New Special Locations
+```python
+'special_locations': {
+    'the_weeping_stones': {
+        'coordinates': (8, 12),
+        'type': 'cursed_monument',
+        'description': 'Ancient standing stones that bleed tears of the innocent',
+        'effects': ['Healing water', 'Attracts undead', 'Prophetic visions'],
+        'connected_to': ['nechrubel_cult', 'shadow_king_followers']
+    },
+    'carnival_of_sorrows': {
+        'coordinates': 'mobile',
+        'type': 'wandering_settlement',
+        'description': 'Cursed traveling carnival that appears in different hexes',
+        'schedule': 'Moves every 1d4 weeks',
+        'offerings': ['Cursed entertainment', 'Soul gambling', 'Demon contracts']
+    }
+}
+```
+
+---
+
+## 📚 Content Tables Enhancements
+
+### 1. Advanced Dungeon Tables
+
+#### Context-Aware Dungeon Generation
+```python
+ADVANCED_DUNGEON_TABLES = {
+    'en': {
+        'dungeon_purposes': [
+            "Ancient god-prison containing forgotten deity",
+            "Plague research facility with living experiments", 
+            "Demon binding circle maintaining ancient pacts",
+            "Noble family crypt with undead patriarchs",
+            "Heretic hideout with forbidden library",
+            "Troll warren with human livestock pens",
+            "Witch laboratory brewing reality-altering potions",
+            "Cult shrine performing soul-harvest rituals"
+        ],
+        'dungeon_complications': [
+            "Entrance only opens during specific celestial events",
+            "Interior geography shifts based on moon phases", 
+            "Requires specific sacrifice to unlock deeper levels",
+            "Protected by riddles that change with each visitor",
+            "Guarded by bound spirits of previous explorers",
+            "Contains temporal anomalies from failed magic",
+            "Infested with plague-spawned mutations",
+            "Watched by faction agents seeking same treasure"
+        ],
+        'dungeon_connections': [
+            "Connected via tunnels to major city sewers",
+            "Part of larger underground network of similar sites",
+            "Shares mystical connection with distant location", 
+            "Built on intersection of ley lines",
+            "Constructed around natural portal to elsewhere",
+            "Contains maps to three other similar dungeons",
+            "Guards entrance to even more dangerous depths",
+            "Temporal loop connects it to past/future events"
+        ]
+    }
+}
+```
+
+### 2. Expanded NPC Generation System
+
+#### Professional NPCs with Motivations
+```python
+NPC_PROFESSION_TABLES = {
+    'en': {
+        'plague_professionals': [
+            "Plague Doctor - Treats disease with experimental methods",
+            "Corpse Collector - Harvests bodies for medical research", 
+            "Quarantine Warden - Enforces isolation protocols",
+            "Disease Merchant - Sells immunity potions and treatments",
+            "Mercy Killer - Ends suffering of the incurable",
+            "Plague Prophet - Preaches disease as divine punishment"
+        ],
+        'religious_outcasts': [
+            "Defrocked Priest - Lost faith, seeks redemption",
+            "Heretic Scholar - Studies forbidden theological texts",
+            "Demon Negotiator - Brokers deals with infernal powers",
+            "Saint Impersonator - Fakes miracles for coin",
+            "Relic Forger - Creates false holy artifacts",
+            "Blasphemy Artist - Creates offensive religious art"
+        ],
+        'survival_specialists': [
+            "Hex Guide - Knows safe paths through dangerous terrain",
+            "Monster Tracker - Hunts dangerous beasts for bounty",
+            "Scavenger Lord - Controls salvage operations in ruins",
+            "Weather Reader - Predicts supernatural storms",
+            "Portal Seeker - Searches for dimensional gateways",
+            "Calendar Scholar - Studies apocalyptic prophecies"
+        ]
+    }
+}
+```
+
+#### NPC Relationship Networks
+```python
+NPC_CONNECTIONS = {
+    'family_bonds': [
+        "Estranged sibling in rival faction",
+        "Child sold to cult for protection",
+        "Spouse transformed by curse or plague",
+        "Parent serving as undead guardian",
+        "Cousin leading opposing organization"
+    ],
+    'professional_ties': [
+        "Former partner in criminal enterprise", 
+        "Apprentice who betrayed mentor",
+        "Rival artisan in same trade",
+        "Creditor demanding impossible payment",
+        "Supplier of illegal or cursed goods"
+    ],
+    'supernatural_connections': [
+        "Bound to serve ancient entity",
+        "Shares soul with demonic patron",
+        "Cursed to speak only truth",
+        "Prophetically linked to party member",
+        "Reincarnated enemy from past life"
+    ]
+}
+```
+
+### 3. Enhanced Bestiary System
+
+#### Ecological Beast Networks
+```python
+BEAST_ECOLOGY_TABLES = {
+    'en': {
+        'pack_behaviors': [
+            "Hunts in coordinated groups of 2d4 individuals",
+            "Alpha leads pack of 1d6 juveniles",
+            "Migrates seasonally following food sources",
+            "Territorial disputes with rival species",
+            "Symbiotic relationship with local cult",
+            "Domesticated by isolated human settlement"
+        ],
+        'environmental_adaptations': [
+            "Thrives in areas of high magical corruption", 
+            "Feeds exclusively on fear and suffering",
+            "Becomes more powerful during misery events",
+            "Hibernates in blessed or consecrated ground",
+            "Multiplies rapidly in the presence of undead",
+            "Weakened by pure moonlight or sunlight"
+        ],
+        'supernatural_traits': [
+            "Can sense approaching doom or disaster",
+            "Memories passed between generations", 
+            "Prophetic dreams shown to those it trusts",
+            "Can phase between material and shadow realm",
+            "Aging reverses in areas of temporal distortion",
+            "Bonds psychically with regular caretakers"
+        ]
+    }
+}
+```
+
+### 4. Advanced Weather and Events System
+
+#### Supernatural Weather Patterns
+```python
+SUPERNATURAL_WEATHER = {
+    'en': {
+        'cursed_weather': [
+            "Rain of black tears that stain everything permanently",
+            "Fog that shows visions of personal fears",
+            "Snow that never melts and whispers accusations", 
+            "Wind that carries voices of the recently dead",
+            "Hail containing frozen screams of the damned",
+            "Lightning that strikes only the guilty"
+        ],
+        'weather_effects': [
+            "All magic becomes unreliable and dangerous",
+            "Dead rise spontaneously during storm",
+            "Time flows backward in affected area",
+            "Emotional state of all present becomes visible",
+            "Metal corrodes rapidly, weapons become brittle",
+            "Supernatural creatures gain enhanced abilities"
+        ],
+        'weather_omens': [
+            "Crows gathering means death approaches",
+            "Sudden temperature drop signals undead presence",
+            "Red clouds promise violence within three days",
+            "Stillness of air indicates supernatural attention", 
+            "Unnatural animal behavior warns of faction movement",
+            "Aurora in wrong season means reality is thinning"
+        ]
+    }
+}
+```
+
+---
+
+## 🔄 Interconnected Content Systems
+
+### 1. Hex Relationship Networks
+
+#### Story Thread Connections
+```python
+HEX_CONNECTIONS = {
+    'quest_chains': {
+        'the_lost_caravan': {
+            'start_hex': '1215',  # Galgenbeck
+            'connected_hexes': ['1315', '1416', '1517'],
+            'story_progression': [
+                'Merchant reports missing caravan',
+                'Find abandoned wagons with cult symbols',
+                'Discover survivors held in cult compound',
+                'Rescue mission reveals larger conspiracy'
+            ],
+            'faction_involvement': ['nechrubel_cult', 'death_merchants']
+        }
+    },
+    'resource_flows': {
+        'plague_water_trade': {
+            'source_hexes': ['0615', '0715'],  # Swamp sources
+            'destination_hexes': ['1215', '0805'],  # Cities buying
+            'route_hexes': ['0716', '0817', '0918'],
+            'dangers': ['Plague bearers', 'Contaminated goods', 'Rival traders']
+        }
+    }
+}
+```
+
+### 2. Seasonal and Calendar Effects
+
+#### Misery Calendar Integration
+```python
+CALENDAR_EFFECTS = {
+    'misery_events': {
+        'the_third_blackened_moon': {
+            'frequency': 'Every 3 months',
+            'regional_effects': {
+                'all': ['Undead more active', 'Magic becomes unstable'],
+                'swamp': ['Plague outbreaks intensify'],
+                'mountain': ['Ancient tombs crack open'], 
+                'forest': ['Trees whisper forbidden knowledge']
+            },
+            'faction_responses': {
+                'nechrubel_cult': 'Mass ritual sacrifices',
+                'forest_witches': 'Protective ward creation',
+                'plague_bearers': 'Spread disease aggressively'
+            }
+        }
+    }
+}
+```
+
+---
+
+## 🔧 Technical Implementation Suggestions
+
+### 1. Database Schema Enhancements
+
+#### Relational Data Structure
+```python
+class FactionInfluence:
+    hex_code: str
+    faction_name: str
+    influence_level: float  # 0.0 to 1.0
+    last_updated: datetime
+    trigger_events: List[str]
+
+class HexConnection:
+    hex_a: str
+    hex_b: str
+    connection_type: str  # 'trade_route', 'tunnel', 'mystical', 'political'
+    active: bool
+    story_significance: str
+
+class DynamicEvent:
+    event_id: str
+    affected_hexes: List[str]
+    duration_days: int
+    effects: Dict[str, Any]
+    triggers: List[str]
+```
+
+### 2. Content Generation Algorithms
+
+#### Weighted Content Selection
+```python
+def generate_context_aware_content(hex_code, surrounding_hexes, faction_influence, calendar_state):
+    """Generate content that considers broader context."""
+    
+    base_weights = get_base_content_weights(terrain_type)
+    
+    # Adjust for faction influence
+    for faction, influence in faction_influence.items():
+        if influence > 0.5:
+            base_weights = apply_faction_modifier(base_weights, faction)
+    
+    # Adjust for calendar events
+    if calendar_state.is_misery_active():
+        base_weights = apply_misery_modifier(base_weights, calendar_state.current_misery)
+    
+    # Adjust for neighboring hex content
+    for neighbor_hex in surrounding_hexes:
+        neighbor_content = get_hex_content(neighbor_hex)
+        base_weights = apply_proximity_modifier(base_weights, neighbor_content)
+    
+    return select_weighted_content(base_weights)
+```
+
+---
+
+## 📊 Content Quality Metrics
+
+### 1. Narrative Coherence Scoring
+- **Faction Consistency**: Do generated NPCs align with regional faction presence?
+- **Environmental Logic**: Are beasts appropriate for their terrain?
+- **Story Connectivity**: Do nearby hexes reference each other appropriately?
+
+### 2. Atmospheric Maintenance
+- **Mörk Borg Tone**: Maintain grimdark, metal aesthetic throughout
+- **Doom Progression**: Content becomes bleaker as apocalypse approaches
+- **Player Agency**: Ensure meaningful choices despite grim setting
+
+---
+
+## 🎯 Priority Implementation Roadmap
+
+### Phase 1: Foundation (Weeks 1-2)
+1. **Integrate Recent Official Content**
+   - Add Ikhon forgotten gods to lore database
+   - Expand major cities with new supplement details
+   - Update faction information with recent developments
+
+2. **Enhance Regional Biases**
+   - Add seasonal variation to regional themes
+   - Implement faction territorial influence
+   - Create special location templates
+
+### Phase 2: Dynamic Systems (Weeks 3-4)
+1. **Faction Evolution Engine**
+   - Implement relationship tracking
+   - Add faction activity generation
+   - Create territorial control system
+
+2. **Advanced NPC Generation**
+   - Professional background system
+   - Relationship network generation
+   - Motivation-driven behavior patterns
+
+### Phase 3: Interconnected Content (Weeks 5-6)
+1. **Hex Relationship Networks**
+   - Story thread connections
+   - Trade route systems
+   - Resource flow modeling
+
+2. **Dynamic Event System**
+   - Calendar-based misery events
+   - Weather pattern effects
+   - Cross-hex event propagation
+
+### Phase 4: Polish and Integration (Weeks 7-8)
+1. **Quality Assurance**
+   - Content coherence validation
+   - Atmospheric consistency checks
+   - Performance optimization
+
+2. **User Interface Updates**
+   - Web interface enhancements for new content
+   - Export formats for connected storylines
+   - GM tools for managing dynamic systems
+
+---
+
+## 📋 Additional Recommendations
+
+### Community Content Integration
+- **Third-Party Supplement Parsing**: Develop system to incorporate popular community supplements
+- **User-Generated Content**: Allow community submissions of verified lore-accurate content
+- **Modular Integration**: Enable/disable specific content packs based on campaign needs
+
+### Accessibility Improvements
+- **Content Filtering**: Allow filtering by theme intensity (body horror, religious themes, etc.)
+- **Language Expansion**: Add support for additional languages beyond EN/PT
+- **Screen Reader Optimization**: Ensure generated content works well with accessibility tools
+
+### Long-term Enhancements
+- **AI-Assisted Expansion**: Use language models to generate additional content in established style
+- **Cross-Campaign Continuity**: Track faction developments across multiple campaigns
+- **Official Partnership**: Explore collaboration opportunities with Free League Publishing
+
+---
+
+## 📖 Conclusion
+
+The Hexy project has established an excellent foundation for Mörk Borg hexcrawl generation. These improvements focus on enhancing the existing systems with:
+
+1. **Deeper Integration** of recent official and community content
+2. **Dynamic Systems** that respond to player actions and campaign progression
+3. **Interconnected Narratives** that create more meaningful exploration
+4. **Enhanced Atmospheric Consistency** maintaining the grimdark aesthetic
+
+The proposed improvements maintain the project's core strengths while addressing identified gaps, ensuring the generator remains true to the Mörk Borg vision while providing richer, more connected content for players and GMs.
+
+**Research compiled by:** AI Assistant  
+**Date:** January 2025  
+**Status:** Ready for Implementation Planning

--- a/src/content_tables.py
+++ b/src/content_tables.py
@@ -95,25 +95,16 @@ DUNGEON_TABLES = {
             "Ancient tomb", "Ruined temple", "Collapsed mine", "Forgotten crypt", "Abandoned tower", 
             "Underground warren", "Sunken cathedral", "Twisted labyrinth", "Bone pit", "Plague house", 
             "Cursed cellar", "Sacrificial chamber",
-            # NEW: From recent supplements and research
-            "Forgotten god-prison", "Plague research facility", "Demon binding circle", 
-            "Noble family crypt with undead patriarchs", "Heretic hideout library", 
-            "Troll warren with human pens", "Witch's reality laboratory", "Soul harvest shrine",
-            "Tax collection dungeon", "Contract devil's vault", "Carnival basement of horrors",
-            "Drowned ship's hold", "Bone crown burial chamber", "Silkfiend's web gallery"
+            # From Christian's supplements
+            "Tax collection dungeon", "Contract devil's vault"
         ],
         'dungeon_features': [
             "flooded with black water", "filled with poisonous gas", "haunted by restless spirits", 
             "overrun with vermin", "decorated with blasphemous murals", "littered with ancient bones", 
             "carved from living rock", "built on unholy ground", "twisted by dark magic", 
             "scarred by old battles", "abandoned in haste", "sealed for good reason",
-            # NEW: Features from recent content
-            "bound by forgotten god's influence", "echoing with cattle lowing from nowhere", 
-            "dripping with tears that form healing pools", "wrapped in silken webs that whisper secrets",
-            "filled with bureaucratic paperwork written in blood", "haunted by the voices of drowned sailors",
-            "decorated with tax ledgers of the damned", "pulsing with the heartbeat of ancient kings",
-            "crawling with plague-mutated vermin", "shifting layout based on lunar phases",
-            "guarded by bound spirits of contract-breakers", "lined with mirrors showing true selves"
+            # From Christian's supplements 
+            "filled with bureaucratic paperwork written in blood"
         ],
         'dungeon_dangers': [
             "Collapsing ceiling", "Pit trap with spikes", "Poisonous gas leak", "Unstable floor", 
@@ -165,14 +156,8 @@ DENIZEN_TABLES = {
             "Witch hunter", "Corrupted priest", "Feral child", "Broken soldier", "Death merchant", 
             "Bone collector", "Grave robber", "Cursed wanderer", "Zealot preacher", "Flesh trader", 
             "Scavenger lord", "Plague bearer", "Doom prophet",
-            # NEW: From recent supplements and forgotten gods
-            "Cattle cultist of the Bilkherd", "Drowned fisherman serving Becklure", 
-            "Necromancer communing with Old Dead", "Spider-silk artist bound to Silkfiend",
-            "Desperate tax collector", "Soul contract negotiator", "Eager day laborer",
-            "Golden tongue merchant", "Plague quarantine warden", "Carnival performer",
-            "Bone crown archaeologist", "Weather-reading witch", "Portal seeker",
-            "Calendar doomsday scholar", "Faction territorial scout", "Resource flow guardian",
-            "Mercy killer for plague victims", "Demon-possessed bureaucrat", "Cursed carnival barker"
+            # From Christian's supplements
+            "Desperate tax collector", "Eager day laborer", "Carnival performer"
         ],
         'denizen_motivations': [
             "seeks redemption for past sins", "hunts for forbidden knowledge", "flees from terrible pursuers",
@@ -221,14 +206,7 @@ BESTIARY_TABLES = {
         'beast_types': [
             "Plague rat", "Corpse crow", "Bone spider", "Blood leech", "Shadow wolf", "Carrion hound",
             "Sewer serpent", "Rust beetle", "Doom moth", "Acid toad", "Spine crawler", "Flesh wasp",
-            "Grave worm", "Blight bat", "Void spider", "Death adder", "Scream bird", "Terror mole",
-            # NEW: Beasts connected to forgotten gods and new factions
-            "Bilkherd's plague cattle", "Becklure's drowned horse", "Old Dead's bone hound", 
-            "Silkfiend's web spinner", "Tax collector's ledger imp", "Contract devil's paper wasp",
-            "Carnival nightmare beast", "Quarantine zone mutant", "Golden tongue greed worm",
-            "Weather-mad storm bird", "Portal-touched phase cat", "Calendar beast of time",
-            "Faction war hound", "Trade route pack mule of bones", "Eager laborer's burden beast",
-            "Weeping stone spirit", "Bone crown specter", "Ministry demon familiar"
+            "Grave worm", "Blight bat", "Void spider", "Death adder", "Scream bird", "Terror mole"
         ],
         'beast_features': [
             "glowing red eyes", "exposed ribs", "rotting flesh", "venomous bite", "acidic saliva",
@@ -308,14 +286,7 @@ LOOT_TABLES = {
         'treasure_types': [
             "Cursed jewelry", "Tainted coins", "Bone ornaments", "Blood gems", "Skull chalices",
             "Ritual daggers", "Plague masks", "Death totems", "Forbidden books", "Soul stones",
-            "Corpse candles", "Grave dirt", "Unholy relics", "Demon bottles", "Witch tools",
-            # NEW: Treasures from forgotten gods and recent supplements
-            "Bilkherd's milk chalice", "Becklure's drowned pearl", "Old Dead's memory stone", 
-            "Silkfiend's fate silk", "Tax ledger written in blood", "Infernal contract fragment",
-            "Carnival soul ticket", "Quarantine doctor's mask", "Golden tongue coin",
-            "Weather prediction bones", "Portal-seeking compass", "Calendar prophecy scroll",
-            "Faction identification badge", "Trade route toll tokens", "Eager laborer's tools",
-            "Weeping stone tears (bottled)", "Bone crown fragment", "Ministry demon seal"
+            "Corpse candles", "Grave dirt", "Unholy relics", "Demon bottles", "Witch tools"
         ],
         'treasure_values': [
             "Worthless but cursed", "Few copper pieces", "Handful of silver", "Small fortune in gold",
@@ -400,110 +371,6 @@ AFFILIATION_TABLES = {
     }
 }
 
-# ===== NEW: FORGOTTEN GODS TABLES =====
-FORGOTTEN_GODS_TABLES = {
-    'en': {
-        'forgotten_god_shrines': [
-            "Hidden cattle pen with Bilkherd altar beneath hay",
-            "Submerged cave shrine to Becklure accessed at low tide",
-            "Ancient tomb entrance guarded by Old Dead whispers",
-            "Silk-wrapped tree grove sacred to the Silkfiend",
-            "Roadside stone circle concealing forgotten god prison",
-            "Abandoned farmhouse cellar with bovine skull altar",
-            "Lighthouse foundation built around drowned god shrine",
-            "Burial mound with talking skeleton priests",
-            "Artist's studio filled with cursed silk tapestries",
-            "Tax office basement hiding infernal contract vault"
-        ],
-        'forgotten_god_gifts': [
-            "Cattle that produce healing milk once per week",
-            "Ability to breathe underwater for one hour daily",
-            "Commune with any corpse older than 100 years",
-            "Weave minor fate changes into reality",
-            "Animals obey simple commands willingly",
-            "Find safe passage across any body of water",
-            "Speak with spirits of the ancient dead",
-            "Create art that shows viewer's true desires",
-            "Livestock always know direction of nearest water",
-            "Dead fish and sea creatures answer questions"
-        ],
-        'forgotten_god_punishments': [
-            "All cattle in area sicken and die within days",
-            "Victim experiences drowning sensations randomly",
-            "Ancient dead rise to torment the unfaithful",
-            "Becomes entangled in unbreakable silk threads",
-            "Livestock flee in terror at victim's approach",
-            "Water turns to blood when victim tries to drink",
-            "Haunted by voices of disappointed ancestors",
-            "Everything victim touches becomes ugly",
-            "Cannot speak without bovine sounds mixing in",
-            "Dreams of drowning in silk cocoons nightly"
-        ],
-        'forgotten_god_rituals': [
-            "Sacrifice finest cow during harvest moon",
-            "Drown offering of fish in sacred tidal pool",
-            "Bury grave goods with ancient bone fragments",
-            "Weave personal secret into silk offering",
-            "Milk sacred cow while chanting prayers",
-            "Cast net into water during storm",
-            "Place skull in tomb while whispering names",
-            "Create artwork depicting patron's domain",
-            "Pour milk libation on stone altar",
-            "Offer drowned sailor's bones to waves"
-        ]
-    },
-    'pt': {
-        'forgotten_god_shrines': [
-            "Curral escondido com altar de Bilkherd sob o feno",
-            "Santuário de caverna submersa para Becklure acessível na maré baixa",
-            "Entrada de tumba antiga guardada por sussurros dos Mortos Antigos",
-            "Bosque de árvores envoltas em seda sagrado ao Demônio da Seda",
-            "Círculo de pedras na beira da estrada escondendo prisão de deus esquecido",
-            "Porão de casa de fazenda abandonada com altar de crânio bovino",
-            "Fundação de farol construída ao redor de santuário de deus afogado",
-            "Monte funerário com sacerdotes esqueletos falantes",
-            "Estúdio de artista cheio de tapeçarias de seda amaldiçoadas",
-            "Porão de escritório de impostos escondendo cofre de contrato infernal"
-        ],
-        'forgotten_god_gifts': [
-            "Gado que produz leite curativo uma vez por semana",
-            "Habilidade de respirar debaixo d'água por uma hora diariamente",
-            "Comungar com qualquer cadáver mais antigo que 100 anos",
-            "Tecer pequenas mudanças do destino na realidade",
-            "Animais obedecem comandos simples voluntariamente",
-            "Encontrar passagem segura através de qualquer corpo d'água",
-            "Falar com espíritos dos mortos antigos",
-            "Criar arte que mostra os verdadeiros desejos do observador",
-            "Gado sempre sabe direção da água mais próxima",
-            "Peixes e criaturas marinhas mortas respondem perguntas"
-        ],
-        'forgotten_god_punishments': [
-            "Todo gado na área adoece e morre em dias",
-            "Vítima experimenta sensações de afogamento aleatoriamente",
-            "Mortos antigos ressurgem para atormentar os infiéis",
-            "Fica emaranhado em fios de seda inquebráveis",
-            "Gado foge em terror na aproximação da vítima",
-            "Água vira sangue quando vítima tenta beber",
-            "Assombrado por vozes de ancestrais desapontados",
-            "Tudo que a vítima toca se torna feio",
-            "Não pode falar sem sons bovinos se misturando",
-            "Sonha com afogamento em casulos de seda todas as noites"
-        ],
-        'forgotten_god_rituals': [
-            "Sacrificar a melhor vaca durante a lua da colheita",
-            "Afogar oferta de peixe em poça sagrada da maré",
-            "Enterrar bens funerários com fragmentos de ossos antigos",
-            "Tecer segredo pessoal em oferta de seda",
-            "Ordenhar vaca sagrada enquanto canta orações",
-            "Lançar rede na água durante tempestade",
-            "Colocar crânio na tumba enquanto sussurra nomes",
-            "Criar obra de arte retratando domínio do patrono",
-            "Derramar libação de leite no altar de pedra",
-            "Oferecer ossos de marinheiro afogado às ondas"
-        ]
-    }
-}
-
 # ===== WILDERNESS TABLES =====
 WILDERNESS_TABLES = {
     'en': {
@@ -517,15 +384,8 @@ WILDERNESS_TABLES = {
             "Stone bridge over rushing water", "Grove of dead trees in perfect circle",
             "Merchant's bones picked clean by crows", "Cave mouth sealed with heavy stones",
             "Battlefield littered with old weapons", "Shrine to forgotten deity", "Gibbet cage swaying empty",
-            # NEW: Encounters referencing forgotten gods and recent content
-            "Abandoned cattle pen with Bilkherd shrine hidden beneath", "Fisherman's boat circling endlessly with no crew aboard",
-            "Tax collector's wagon overturned, papers scattered and bloodstained", "Carnival tent flapping empty in the wind",
-            "Ancient standing stones weeping tears that pool in healing puddles", "Silk-wrapped trees forming unnatural patterns",
-            "Quarantine flags marking a plague zone ahead", "Bone crown partially buried in roadside earth",
-            "Contract papers nailed to tree, written in infernal script", "Eager laborers digging a hole to nowhere",
-            "Weather vane spinning wildly despite no wind", "Portal-seeking expedition's abandoned camp",
-            "Calendar scholars' camp with astronomical instruments", "Faction scouts' hidden watchtower",
-            "Trade route guard post mysteriously empty", "Drowned sailor walking inland seeking the sea"
+            # From Christian's supplements
+            "Tax collector's wagon overturned, papers scattered and bloodstained"
         ],
         'random_events': [
             "A murder of crows follows the party ominously", "Strange lights dance in the distance",
@@ -551,15 +411,7 @@ WILDERNESS_TABLES = {
             "Ponte de pedra sobre água corrente", "Bosque de árvores mortas em círculo perfeito",
             "Ossos de mercador limpos por corvos", "Boca de caverna selada com pedras pesadas",
             "Campo de batalha coberto de armas velhas", "Santuário de divindade esquecida", "Gaiola de patíbulo balançando vazia",
-            # NEW: Encounters referencing forgotten gods and recent content
-            "Fazenda abandonada de gado com o santuário de Bilkherd escondido por baixo", "Barco do pescador que circula infinitamente sem tripulantes",
-            "Cavaleiro de cobrança de impostos com carroza virada, papéis espalhados e manchados de sangue", "Tentativa de circo vazia flutuando no vento",
-            "Pedras de pedra antigas chorando lágrimas que se acumulam em poças de cura", "Árvores enroscadas em padrões artificiais",
-            "Bandeiras de quarentena marcando uma zona de peste à frente", "Crista de caveira parcialmente enterrada na terra do lado da estrada",
-            "Papéis de contrato pregados em árvore, escritos em script infernal", "Trabalhadores ávidos cavando um buraco para onde não vai",
-            "Girassol com lâmpada que gira freneticamente sem vento", "Acampamento abandonado de expedicionário em busca de portal",
-            "Acampamento de estudiosos com instrumentos astronômicos", "Torre de vigia escondida de espiões",
-            "Posto de guarda de rota de comércio misteriosamente vazio", "Marinheiro afogado andando para terra em busca do mar"
+            "Cavaleiro de cobrança de impostos com carroza virada, papéis espalhados e manchados de sangue"
         ],
         'random_events': [
             "Um bando de corvos segue o grupo sinistro", "Luzes estranhas dançam na distância",
@@ -860,7 +712,6 @@ def get_table(category, table_name, language='en'):
         'enhanced_loot': ENHANCED_LOOT_TABLES,
         'terrain': TERRAIN_TABLES,
         'core': CORE_TABLES,
-        'forgotten_gods': FORGOTTEN_GODS_TABLES,
     }
     
     return table_categories.get(category, {}).get(language, {}).get(table_name, [])
@@ -871,7 +722,7 @@ def get_all_tables(language='en'):
     categories = [BASIC_TABLES, NAMING_TABLES, TAVERN_TABLES, DUNGEON_TABLES, 
                  DENIZEN_TABLES, BESTIARY_TABLES, SCROLL_TABLES, LOOT_TABLES, 
                  AFFILIATION_TABLES, WILDERNESS_TABLES, STATS_TABLES, ENHANCED_LOOT_TABLES,
-                 TERRAIN_TABLES, CORE_TABLES, FORGOTTEN_GODS_TABLES]
+                 TERRAIN_TABLES, CORE_TABLES]
     
     for category in categories:
         if language in category:
@@ -881,7 +732,7 @@ def get_all_tables(language='en'):
 
 def list_categories():
     """List all available table categories."""
-    return ['basic', 'naming', 'tavern', 'dungeon', 'denizen', 'bestiary', 'scroll', 'loot', 'affiliation', 'wilderness', 'stats', 'enhanced_loot', 'terrain', 'core', 'forgotten_gods']
+    return ['basic', 'naming', 'tavern', 'dungeon', 'denizen', 'bestiary', 'scroll', 'loot', 'affiliation', 'wilderness', 'stats', 'enhanced_loot', 'terrain', 'core']
 
 def list_tables_in_category(category, language='en'):
     """List all tables in a specific category."""
@@ -900,7 +751,6 @@ def list_tables_in_category(category, language='en'):
         'enhanced_loot': ENHANCED_LOOT_TABLES,
         'terrain': TERRAIN_TABLES,
         'core': CORE_TABLES,
-        'forgotten_gods': FORGOTTEN_GODS_TABLES,
     }
     
     category_tables = table_categories.get(category, {}).get(language, {})

--- a/src/content_tables.py
+++ b/src/content_tables.py
@@ -94,13 +94,26 @@ DUNGEON_TABLES = {
         'dungeon_types': [
             "Ancient tomb", "Ruined temple", "Collapsed mine", "Forgotten crypt", "Abandoned tower", 
             "Underground warren", "Sunken cathedral", "Twisted labyrinth", "Bone pit", "Plague house", 
-            "Cursed cellar", "Sacrificial chamber"
+            "Cursed cellar", "Sacrificial chamber",
+            # NEW: From recent supplements and research
+            "Forgotten god-prison", "Plague research facility", "Demon binding circle", 
+            "Noble family crypt with undead patriarchs", "Heretic hideout library", 
+            "Troll warren with human pens", "Witch's reality laboratory", "Soul harvest shrine",
+            "Tax collection dungeon", "Contract devil's vault", "Carnival basement of horrors",
+            "Drowned ship's hold", "Bone crown burial chamber", "Silkfiend's web gallery"
         ],
         'dungeon_features': [
             "flooded with black water", "filled with poisonous gas", "haunted by restless spirits", 
             "overrun with vermin", "decorated with blasphemous murals", "littered with ancient bones", 
             "carved from living rock", "built on unholy ground", "twisted by dark magic", 
-            "scarred by old battles", "abandoned in haste", "sealed for good reason"
+            "scarred by old battles", "abandoned in haste", "sealed for good reason",
+            # NEW: Features from recent content
+            "bound by forgotten god's influence", "echoing with cattle lowing from nowhere", 
+            "dripping with tears that form healing pools", "wrapped in silken webs that whisper secrets",
+            "filled with bureaucratic paperwork written in blood", "haunted by the voices of drowned sailors",
+            "decorated with tax ledgers of the damned", "pulsing with the heartbeat of ancient kings",
+            "crawling with plague-mutated vermin", "shifting layout based on lunar phases",
+            "guarded by bound spirits of contract-breakers", "lined with mirrors showing true selves"
         ],
         'dungeon_dangers': [
             "Collapsing ceiling", "Pit trap with spikes", "Poisonous gas leak", "Unstable floor", 
@@ -151,7 +164,15 @@ DENIZEN_TABLES = {
             "Diseased beggar", "Mad hermit", "Wandering cultist", "Desperate bandit", "Plague doctor", 
             "Witch hunter", "Corrupted priest", "Feral child", "Broken soldier", "Death merchant", 
             "Bone collector", "Grave robber", "Cursed wanderer", "Zealot preacher", "Flesh trader", 
-            "Scavenger lord", "Plague bearer", "Doom prophet"
+            "Scavenger lord", "Plague bearer", "Doom prophet",
+            # NEW: From recent supplements and forgotten gods
+            "Cattle cultist of the Bilkherd", "Drowned fisherman serving Becklure", 
+            "Necromancer communing with Old Dead", "Spider-silk artist bound to Silkfiend",
+            "Desperate tax collector", "Soul contract negotiator", "Eager day laborer",
+            "Golden tongue merchant", "Plague quarantine warden", "Carnival performer",
+            "Bone crown archaeologist", "Weather-reading witch", "Portal seeker",
+            "Calendar doomsday scholar", "Faction territorial scout", "Resource flow guardian",
+            "Mercy killer for plague victims", "Demon-possessed bureaucrat", "Cursed carnival barker"
         ],
         'denizen_motivations': [
             "seeks redemption for past sins", "hunts for forbidden knowledge", "flees from terrible pursuers",
@@ -200,7 +221,14 @@ BESTIARY_TABLES = {
         'beast_types': [
             "Plague rat", "Corpse crow", "Bone spider", "Blood leech", "Shadow wolf", "Carrion hound",
             "Sewer serpent", "Rust beetle", "Doom moth", "Acid toad", "Spine crawler", "Flesh wasp",
-            "Grave worm", "Blight bat", "Void spider", "Death adder", "Scream bird", "Terror mole"
+            "Grave worm", "Blight bat", "Void spider", "Death adder", "Scream bird", "Terror mole",
+            # NEW: Beasts connected to forgotten gods and new factions
+            "Bilkherd's plague cattle", "Becklure's drowned horse", "Old Dead's bone hound", 
+            "Silkfiend's web spinner", "Tax collector's ledger imp", "Contract devil's paper wasp",
+            "Carnival nightmare beast", "Quarantine zone mutant", "Golden tongue greed worm",
+            "Weather-mad storm bird", "Portal-touched phase cat", "Calendar beast of time",
+            "Faction war hound", "Trade route pack mule of bones", "Eager laborer's burden beast",
+            "Weeping stone spirit", "Bone crown specter", "Ministry demon familiar"
         ],
         'beast_features': [
             "glowing red eyes", "exposed ribs", "rotting flesh", "venomous bite", "acidic saliva",
@@ -280,7 +308,14 @@ LOOT_TABLES = {
         'treasure_types': [
             "Cursed jewelry", "Tainted coins", "Bone ornaments", "Blood gems", "Skull chalices",
             "Ritual daggers", "Plague masks", "Death totems", "Forbidden books", "Soul stones",
-            "Corpse candles", "Grave dirt", "Unholy relics", "Demon bottles", "Witch tools"
+            "Corpse candles", "Grave dirt", "Unholy relics", "Demon bottles", "Witch tools",
+            # NEW: Treasures from forgotten gods and recent supplements
+            "Bilkherd's milk chalice", "Becklure's drowned pearl", "Old Dead's memory stone", 
+            "Silkfiend's fate silk", "Tax ledger written in blood", "Infernal contract fragment",
+            "Carnival soul ticket", "Quarantine doctor's mask", "Golden tongue coin",
+            "Weather prediction bones", "Portal-seeking compass", "Calendar prophecy scroll",
+            "Faction identification badge", "Trade route toll tokens", "Eager laborer's tools",
+            "Weeping stone tears (bottled)", "Bone crown fragment", "Ministry demon seal"
         ],
         'treasure_values': [
             "Worthless but cursed", "Few copper pieces", "Handful of silver", "Small fortune in gold",
@@ -365,6 +400,110 @@ AFFILIATION_TABLES = {
     }
 }
 
+# ===== NEW: FORGOTTEN GODS TABLES =====
+FORGOTTEN_GODS_TABLES = {
+    'en': {
+        'forgotten_god_shrines': [
+            "Hidden cattle pen with Bilkherd altar beneath hay",
+            "Submerged cave shrine to Becklure accessed at low tide",
+            "Ancient tomb entrance guarded by Old Dead whispers",
+            "Silk-wrapped tree grove sacred to the Silkfiend",
+            "Roadside stone circle concealing forgotten god prison",
+            "Abandoned farmhouse cellar with bovine skull altar",
+            "Lighthouse foundation built around drowned god shrine",
+            "Burial mound with talking skeleton priests",
+            "Artist's studio filled with cursed silk tapestries",
+            "Tax office basement hiding infernal contract vault"
+        ],
+        'forgotten_god_gifts': [
+            "Cattle that produce healing milk once per week",
+            "Ability to breathe underwater for one hour daily",
+            "Commune with any corpse older than 100 years",
+            "Weave minor fate changes into reality",
+            "Animals obey simple commands willingly",
+            "Find safe passage across any body of water",
+            "Speak with spirits of the ancient dead",
+            "Create art that shows viewer's true desires",
+            "Livestock always know direction of nearest water",
+            "Dead fish and sea creatures answer questions"
+        ],
+        'forgotten_god_punishments': [
+            "All cattle in area sicken and die within days",
+            "Victim experiences drowning sensations randomly",
+            "Ancient dead rise to torment the unfaithful",
+            "Becomes entangled in unbreakable silk threads",
+            "Livestock flee in terror at victim's approach",
+            "Water turns to blood when victim tries to drink",
+            "Haunted by voices of disappointed ancestors",
+            "Everything victim touches becomes ugly",
+            "Cannot speak without bovine sounds mixing in",
+            "Dreams of drowning in silk cocoons nightly"
+        ],
+        'forgotten_god_rituals': [
+            "Sacrifice finest cow during harvest moon",
+            "Drown offering of fish in sacred tidal pool",
+            "Bury grave goods with ancient bone fragments",
+            "Weave personal secret into silk offering",
+            "Milk sacred cow while chanting prayers",
+            "Cast net into water during storm",
+            "Place skull in tomb while whispering names",
+            "Create artwork depicting patron's domain",
+            "Pour milk libation on stone altar",
+            "Offer drowned sailor's bones to waves"
+        ]
+    },
+    'pt': {
+        'forgotten_god_shrines': [
+            "Curral escondido com altar de Bilkherd sob o feno",
+            "Santuário de caverna submersa para Becklure acessível na maré baixa",
+            "Entrada de tumba antiga guardada por sussurros dos Mortos Antigos",
+            "Bosque de árvores envoltas em seda sagrado ao Demônio da Seda",
+            "Círculo de pedras na beira da estrada escondendo prisão de deus esquecido",
+            "Porão de casa de fazenda abandonada com altar de crânio bovino",
+            "Fundação de farol construída ao redor de santuário de deus afogado",
+            "Monte funerário com sacerdotes esqueletos falantes",
+            "Estúdio de artista cheio de tapeçarias de seda amaldiçoadas",
+            "Porão de escritório de impostos escondendo cofre de contrato infernal"
+        ],
+        'forgotten_god_gifts': [
+            "Gado que produz leite curativo uma vez por semana",
+            "Habilidade de respirar debaixo d'água por uma hora diariamente",
+            "Comungar com qualquer cadáver mais antigo que 100 anos",
+            "Tecer pequenas mudanças do destino na realidade",
+            "Animais obedecem comandos simples voluntariamente",
+            "Encontrar passagem segura através de qualquer corpo d'água",
+            "Falar com espíritos dos mortos antigos",
+            "Criar arte que mostra os verdadeiros desejos do observador",
+            "Gado sempre sabe direção da água mais próxima",
+            "Peixes e criaturas marinhas mortas respondem perguntas"
+        ],
+        'forgotten_god_punishments': [
+            "Todo gado na área adoece e morre em dias",
+            "Vítima experimenta sensações de afogamento aleatoriamente",
+            "Mortos antigos ressurgem para atormentar os infiéis",
+            "Fica emaranhado em fios de seda inquebráveis",
+            "Gado foge em terror na aproximação da vítima",
+            "Água vira sangue quando vítima tenta beber",
+            "Assombrado por vozes de ancestrais desapontados",
+            "Tudo que a vítima toca se torna feio",
+            "Não pode falar sem sons bovinos se misturando",
+            "Sonha com afogamento em casulos de seda todas as noites"
+        ],
+        'forgotten_god_rituals': [
+            "Sacrificar a melhor vaca durante a lua da colheita",
+            "Afogar oferta de peixe em poça sagrada da maré",
+            "Enterrar bens funerários com fragmentos de ossos antigos",
+            "Tecer segredo pessoal em oferta de seda",
+            "Ordenhar vaca sagrada enquanto canta orações",
+            "Lançar rede na água durante tempestade",
+            "Colocar crânio na tumba enquanto sussurra nomes",
+            "Criar obra de arte retratando domínio do patrono",
+            "Derramar libação de leite no altar de pedra",
+            "Oferecer ossos de marinheiro afogado às ondas"
+        ]
+    }
+}
+
 # ===== WILDERNESS TABLES =====
 WILDERNESS_TABLES = {
     'en': {
@@ -377,7 +516,16 @@ WILDERNESS_TABLES = {
             "Trail of blood leading into darkness", "Shepherd's hut with door hanging open",
             "Stone bridge over rushing water", "Grove of dead trees in perfect circle",
             "Merchant's bones picked clean by crows", "Cave mouth sealed with heavy stones",
-            "Battlefield littered with old weapons", "Shrine to forgotten deity", "Gibbet cage swaying empty"
+            "Battlefield littered with old weapons", "Shrine to forgotten deity", "Gibbet cage swaying empty",
+            # NEW: Encounters referencing forgotten gods and recent content
+            "Abandoned cattle pen with Bilkherd shrine hidden beneath", "Fisherman's boat circling endlessly with no crew aboard",
+            "Tax collector's wagon overturned, papers scattered and bloodstained", "Carnival tent flapping empty in the wind",
+            "Ancient standing stones weeping tears that pool in healing puddles", "Silk-wrapped trees forming unnatural patterns",
+            "Quarantine flags marking a plague zone ahead", "Bone crown partially buried in roadside earth",
+            "Contract papers nailed to tree, written in infernal script", "Eager laborers digging a hole to nowhere",
+            "Weather vane spinning wildly despite no wind", "Portal-seeking expedition's abandoned camp",
+            "Calendar scholars' camp with astronomical instruments", "Faction scouts' hidden watchtower",
+            "Trade route guard post mysteriously empty", "Drowned sailor walking inland seeking the sea"
         ],
         'random_events': [
             "A murder of crows follows the party ominously", "Strange lights dance in the distance",
@@ -402,7 +550,16 @@ WILDERNESS_TABLES = {
             "Trilha de sangue levando à escuridão", "Cabana de pastor com porta escancarada",
             "Ponte de pedra sobre água corrente", "Bosque de árvores mortas em círculo perfeito",
             "Ossos de mercador limpos por corvos", "Boca de caverna selada com pedras pesadas",
-            "Campo de batalha coberto de armas velhas", "Santuário de divindade esquecida", "Gaiola de patíbulo balançando vazia"
+            "Campo de batalha coberto de armas velhas", "Santuário de divindade esquecida", "Gaiola de patíbulo balançando vazia",
+            # NEW: Encounters referencing forgotten gods and recent content
+            "Fazenda abandonada de gado com o santuário de Bilkherd escondido por baixo", "Barco do pescador que circula infinitamente sem tripulantes",
+            "Cavaleiro de cobrança de impostos com carroza virada, papéis espalhados e manchados de sangue", "Tentativa de circo vazia flutuando no vento",
+            "Pedras de pedra antigas chorando lágrimas que se acumulam em poças de cura", "Árvores enroscadas em padrões artificiais",
+            "Bandeiras de quarentena marcando uma zona de peste à frente", "Crista de caveira parcialmente enterrada na terra do lado da estrada",
+            "Papéis de contrato pregados em árvore, escritos em script infernal", "Trabalhadores ávidos cavando um buraco para onde não vai",
+            "Girassol com lâmpada que gira freneticamente sem vento", "Acampamento abandonado de expedicionário em busca de portal",
+            "Acampamento de estudiosos com instrumentos astronômicos", "Torre de vigia escondida de espiões",
+            "Posto de guarda de rota de comércio misteriosamente vazio", "Marinheiro afogado andando para terra em busca do mar"
         ],
         'random_events': [
             "Um bando de corvos segue o grupo sinistro", "Luzes estranhas dançam na distância",
@@ -456,7 +613,7 @@ STATS_TABLES = {
             'normal': {'hp': '1d6', 'armor': '12', 'morale': '7', 'damage': '1d6'},
             'strong': {'hp': '2d6', 'armor': '14', 'morale': '8', 'damage': '1d8'},
             'elite': {'hp': '3d6', 'armor': '16', 'morale': '9', 'damage': '1d10'},
-            'boss': {'hp': '4d6+4', 'armor': '18', 'morale': '10', 'damage': '2d6'}
+            "boss": {'hp': '4d6+4', 'armor': '18', 'morale': '10', 'damage': '2d6'}
         },
         'npc_stats': {
             'peasant': {'hp': '1d4', 'armor': '10', 'morale': '5', 'damage': '1d3'},
@@ -703,6 +860,7 @@ def get_table(category, table_name, language='en'):
         'enhanced_loot': ENHANCED_LOOT_TABLES,
         'terrain': TERRAIN_TABLES,
         'core': CORE_TABLES,
+        'forgotten_gods': FORGOTTEN_GODS_TABLES,
     }
     
     return table_categories.get(category, {}).get(language, {}).get(table_name, [])
@@ -713,7 +871,7 @@ def get_all_tables(language='en'):
     categories = [BASIC_TABLES, NAMING_TABLES, TAVERN_TABLES, DUNGEON_TABLES, 
                  DENIZEN_TABLES, BESTIARY_TABLES, SCROLL_TABLES, LOOT_TABLES, 
                  AFFILIATION_TABLES, WILDERNESS_TABLES, STATS_TABLES, ENHANCED_LOOT_TABLES,
-                 TERRAIN_TABLES, CORE_TABLES]
+                 TERRAIN_TABLES, CORE_TABLES, FORGOTTEN_GODS_TABLES]
     
     for category in categories:
         if language in category:
@@ -723,7 +881,7 @@ def get_all_tables(language='en'):
 
 def list_categories():
     """List all available table categories."""
-    return ['basic', 'naming', 'tavern', 'dungeon', 'denizen', 'bestiary', 'scroll', 'loot', 'affiliation', 'wilderness', 'stats', 'enhanced_loot', 'terrain', 'core']
+    return ['basic', 'naming', 'tavern', 'dungeon', 'denizen', 'bestiary', 'scroll', 'loot', 'affiliation', 'wilderness', 'stats', 'enhanced_loot', 'terrain', 'core', 'forgotten_gods']
 
 def list_tables_in_category(category, language='en'):
     """List all tables in a specific category."""
@@ -742,6 +900,7 @@ def list_tables_in_category(category, language='en'):
         'enhanced_loot': ENHANCED_LOOT_TABLES,
         'terrain': TERRAIN_TABLES,
         'core': CORE_TABLES,
+        'forgotten_gods': FORGOTTEN_GODS_TABLES,
     }
     
     category_tables = table_categories.get(category, {}).get(language, {})

--- a/src/content_tables.py
+++ b/src/content_tables.py
@@ -96,7 +96,9 @@ DUNGEON_TABLES = {
             "Underground warren", "Sunken cathedral", "Twisted labyrinth", "Bone pit", "Plague house", 
             "Cursed cellar", "Sacrificial chamber",
             # From Christian's supplements
-            "Tax collection dungeon", "Contract devil's vault"
+            "Tax collection dungeon", "Contract devil's vault", "Demon-infested vault", 
+            "Corpse golem laboratory", "Occult channeling circle", "Soul binding chamber",
+            "Sacrifice altar complex", "Heretic hideout", "Golden tongue shrine"
         ],
         'dungeon_features': [
             "flooded with black water", "filled with poisonous gas", "haunted by restless spirits", 
@@ -157,7 +159,9 @@ DENIZEN_TABLES = {
             "Bone collector", "Grave robber", "Cursed wanderer", "Zealot preacher", "Flesh trader", 
             "Scavenger lord", "Plague bearer", "Doom prophet",
             # From Christian's supplements
-            "Desperate tax collector", "Eager day laborer", "Carnival performer"
+            "Desperate tax collector", "Eager day laborer", "Soul contract negotiator", 
+            "Sacrifice heretic", "Corpse golem cultist", "Occult channeler", "Golden tongue preacher",
+            "Contract devil", "Memory eraser", "Bone mill worker"
         ],
         'denizen_motivations': [
             "seeks redemption for past sins", "hunts for forbidden knowledge", "flees from terrible pursuers",
@@ -286,7 +290,11 @@ LOOT_TABLES = {
         'treasure_types': [
             "Cursed jewelry", "Tainted coins", "Bone ornaments", "Blood gems", "Skull chalices",
             "Ritual daggers", "Plague masks", "Death totems", "Forbidden books", "Soul stones",
-            "Corpse candles", "Grave dirt", "Unholy relics", "Demon bottles", "Witch tools"
+            "Corpse candles", "Grave dirt", "Unholy relics", "Demon bottles", "Witch tools",
+            # From Christian's supplements
+            "Soul contract parchment", "Tax ledger written in blood", "Sacrifice knife", 
+            "Corpse golem parts", "Occult channeling crystal", "Golden tongue coin",
+            "Memory stone", "Heretic's diary", "Demon binding chains", "Bone mill flour"
         ],
         'treasure_values': [
             "Worthless but cursed", "Few copper pieces", "Handful of silver", "Small fortune in gold",
@@ -305,7 +313,10 @@ LOOT_TABLES = {
             "Joias amaldiçoadas", "Moedas contaminadas", "Ornamentos de osso", "Gemas sangrentas", 
             "Cálices de caveira", "Punhais rituais", "Máscaras da peste", "Totens da morte", 
             "Livros proibidos", "Pedras da alma", "Velas de cadáver", "Terra de sepultura", 
-            "Relíquias profanas", "Garrafas demoníacas", "Ferramentas de bruxa"
+            "Relíquias profanas", "Garrafas demoníacas", "Ferramentas de bruxa",
+            "Pergaminho de contrato de alma", "Caderneta de imposto de sangue escrita", "Faca de sacrifício",
+            "Partes de golema de cadáver", "Cristal de canalização oculto", "Moeda de língua dourada",
+            "Pedra da memória", "Diário do herege", "Cadeias de enfraquecimento demoníaco", "Farinha de moinho de ossos"
         ],
         'treasure_values': [
             "Sem valor mas amaldiçoado", "Algumas moedas de cobre", "Punhado de prata", 
@@ -382,10 +393,13 @@ WILDERNESS_TABLES = {
             "Ritual circle drawn in ash and bone", "Well with rope cut and bucket missing",
             "Trail of blood leading into darkness", "Shepherd's hut with door hanging open",
             "Stone bridge over rushing water", "Grove of dead trees in perfect circle",
-            "Merchant's bones picked clean by crows", "Cave mouth sealed with heavy stones",
-            "Battlefield littered with old weapons", "Shrine to forgotten deity", "Gibbet cage swaying empty",
+            "Merchant's bones picked clean by scavengers", "Abandoned camp with cold fire",
+            "Cursed windmill with broken blades", "Crossroads shrine to forgotten saints",
             # From Christian's supplements
-            "Tax collector's wagon overturned, papers scattered and bloodstained"
+            "Tax collector's overturned cart with spilled ledgers", "Soul contract fluttering in the wind",
+            "Sacrifice altar with dried blood stains", "Corpse golem shambling through the mist",
+            "Occult channelers performing mountain ritual", "Golden tongue cultist preaching to stones",
+            "Memory gap where something important was forgotten", "Heretic's abandoned hideout"
         ],
         'random_events': [
             "A murder of crows follows the party ominously", "Strange lights dance in the distance",

--- a/src/mork_borg_lore_database.py
+++ b/src/mork_borg_lore_database.py
@@ -33,17 +33,13 @@ class MorkBorgLoreDatabase:
                     'Ruled by mysterious council',
                     'Famous for its hanging gardens of corpses',
                     'Underground sewers with ancient horrors',
-                    'Ministry of Wealth & Taxes extracting souls as currency',
-                    'Guild of the Utmost Eager Day Laborers seeking any work',
-                    'House of Binding Contracts where devils broker deals',
-                    'Daily mandatory festivals causing economic standstill',
-                    'Demon infestation in government buildings',
-                    'Silver coin shortage due to ravenous taxation',
-                    'Cult of the Golden Tongue corrupting merchants',
-                    'Heptaliths - seven cursed standing stones in the city center'
+                    'Schleswig district with demon infestation',
+                    'Ministry of Wealth & Taxes',
+                    'Guild of the Utmost Eager Day Laborers',
+                    'House of Binding Contracts'
                 ],
-                'key_npcs': ['Josilfa Migol', 'The Galgenbeck Council', 'Tax Collectors', 'Contract Devils', 'Eager Day Laborers'],
-                'atmosphere': 'Urban decay and ancient evil mixed with bureaucratic horror'
+                'key_npcs': ['Josilfa Migol', 'The Galgenbeck Council'],
+                'atmosphere': 'Urban decay and ancient evil'
             },
             
             'bergen_chrypt': {
@@ -194,68 +190,6 @@ class MorkBorgLoreDatabase:
                 'regions': ['northwest', 'forest'],
                 'influence': 'magical',
                 'goals': ['Protect ancient secrets', 'Maintain balance', 'Forest preservation']
-            },
-            
-            # NEW: Forgotten Gods Cults (from Ikhon supplement)
-            'bilkherd_cult': {
-                'name': 'Servants of the Bilkherd',
-                'name_pt': 'Servos do Bilkherd',
-                'description': 'Cattle herders and farmers serving the forgotten god of livestock',
-                'description_pt': 'Criadores de gado e fazendeiros servindo o deus esquecido do gado',
-                'regions': ['south', 'central', 'plains'],
-                'influence': 'agricultural',
-                'goals': ['Increase livestock yields', 'Perform cattle sacrifices', 'Spread pastoral corruption']
-            },
-            
-            'becklure_cult': {
-                'name': 'Drowned Servants of the Becklure',
-                'name_pt': 'Servos Afogados do Becklure',
-                'description': 'Fishermen and coastal dwellers serving the water deity',
-                'description_pt': 'Pescadores e moradores costeiros servindo a divindade da água',
-                'regions': ['coast', 'swamp'],
-                'influence': 'maritime',
-                'goals': ['Control waterways', 'Drown the unfaithful', 'Seek sunken treasures']
-            },
-            
-            'old_dead_cult': {
-                'name': 'Whisperers to the Old Dead',
-                'name_pt': 'Sussurradores aos Mortos Antigos',
-                'description': 'Necromancers and grave-robbers serving ancient corpses',
-                'description_pt': 'Necromantes e saqueadores de túmulos servindo cadáveres antigos',
-                'regions': ['north', 'mountain', 'underground'],
-                'influence': 'necromantic',
-                'goals': ['Commune with ancient dead', 'Gather lost knowledge', 'Raise forgotten armies']
-            },
-            
-            'silkfiend_cult': {
-                'name': 'Bound by the Silkfiend',
-                'name_pt': 'Presos pelo Demônio da Seda',
-                'description': 'Artists and craftsmen enslaved by the spider deity',
-                'description_pt': 'Artistas e artesãos escravizados pela divindade aranha',
-                'regions': ['central', 'urban'],
-                'influence': 'artistic',
-                'goals': ['Create cursed artworks', 'Weave fate itself', 'Trap souls in silk']
-            },
-            
-            # NEW: Recent supplement factions
-            'golden_tongue_cult': {
-                'name': 'Cult of the Golden Tongue',
-                'name_pt': 'Culto da Língua Dourada',
-                'description': 'Merchants and tax collectors serving greed incarnate',
-                'description_pt': 'Mercadores e cobradores de impostos servindo a ganância encarnada',
-                'regions': ['central', 'urban'],
-                'influence': 'economic',
-                'goals': ['Accumulate wealth', 'Corrupt through greed', 'Control commerce']
-            },
-            
-            'eager_day_laborers': {
-                'name': 'Guild of the Utmost Eager Day Laborers',
-                'name_pt': 'Guilda dos Mais Ansiosos Trabalhadores Diários',
-                'description': 'Desperate workers performing any task for coin',
-                'description_pt': 'Trabalhadores desesperados realizando qualquer tarefa por moedas',
-                'regions': ['central', 'urban'],
-                'influence': 'labor',
-                'goals': ['Find work at any cost', 'Serve highest bidder', 'Survive another day']
             }
         }
     
@@ -393,86 +327,6 @@ class MorkBorgLoreDatabase:
             'locked': True
         }
         
-        # NEW: Additional special locations from research
-        hardcoded['0812'] = {
-            'type': 'special_location',
-            'name': 'The Weeping Stones',
-            'name_pt': 'As Pedras Chorosas',
-            'terrain': 'plains',
-            'description': 'Ancient standing stones that bleed tears of the innocent',
-            'description_pt': 'Pedras eretas antigas que sangram lágrimas dos inocentes',
-            'atmosphere': 'Ancient sorrow and mystical power',
-            'notable_features': ['Healing tears', 'Attracts undead at night', 'Prophetic visions'],
-            'factions': ['nechrubel_cult', 'shadow_king_followers'],
-            'locked': True
-        }
-        
-        hardcoded['1820'] = {
-            'type': 'special_location',
-            'name': 'Plague Ship Graveyard',
-            'name_pt': 'Cemitério de Navios da Peste',
-            'terrain': 'coast',
-            'description': 'Dozens of diseased vessels run aground on cursed shores',
-            'description_pt': 'Dezenas de navios doentes encalhados em costas amaldiçoadas',
-            'atmosphere': 'Maritime decay and disease',
-            'notable_features': ['Valuable cargo among the dead', 'Plague zombies crew the ships', 'Storm spirits guard the wrecks'],
-            'factions': ['plague_bearers', 'becklure_cult'],
-            'locked': True
-        }
-        
-        hardcoded['0409'] = {
-            'type': 'special_location',
-            'name': 'The Carnival of Sorrows',
-            'name_pt': 'O Carnaval das Tristezas',
-            'terrain': 'plains',  # Mobile, but needs a starting terrain
-            'description': 'Cursed traveling carnival that appears without warning',
-            'description_pt': 'Carnaval amaldiçoado viajante que aparece sem aviso',
-            'atmosphere': 'False joy masking eternal torment',
-            'notable_features': ['Moves every 1d4 weeks', 'Soul gambling games', 'Demonic performers'],
-            'factions': ['silkfiend_cult', 'eager_day_laborers'],
-            'special_properties': ['mobile_location', 'changes_hex_randomly'],
-            'locked': True
-        }
-        
-        hardcoded['2205'] = {
-            'type': 'special_location',
-            'name': 'The Bone Crown Barrows',
-            'name_pt': 'Os Túmulos da Coroa Óssea',
-            'terrain': 'mountain',
-            'description': 'Ancient burial mounds of forgotten kings',
-            'description_pt': 'Montículos funerários antigos de reis esquecidos',
-            'atmosphere': 'Royal death and ancient majesty',
-            'notable_features': ['Crowned skeletons that still rule', 'Treasures beyond imagining', 'Curse upon grave robbers'],
-            'factions': ['old_dead_cult', 'shadow_king_followers'],
-            'locked': True
-        }
-        
-        hardcoded['1618'] = {
-            'type': 'special_location',
-            'name': 'The Ministry of Wealth & Taxes',
-            'name_pt': 'O Ministério da Riqueza e Impostos',
-            'terrain': 'plains',
-            'description': 'Demon-infested government building extracting wealth from souls',
-            'description_pt': 'Prédio governamental infestado de demônios extraindo riqueza das almas',
-            'atmosphere': 'Bureaucratic horror and financial damnation',
-            'notable_features': ['Devils in fine suits', 'Contracts written in blood', 'Vault of stolen souls'],
-            'factions': ['golden_tongue_cult', 'eager_day_laborers'],
-            'locked': True
-        }
-        
-        hardcoded['0722'] = {
-            'type': 'special_location',
-            'name': 'The Quarantine Islands',
-            'name_pt': 'As Ilhas de Quarentena',
-            'terrain': 'coast',
-            'description': 'Isolated islands where plague victims are abandoned',
-            'description_pt': 'Ilhas isoladas onde vítimas da peste são abandonadas',
-            'atmosphere': 'Abandonment and slow death',
-            'notable_features': ['Desperate survivors', 'Mutated plague strains', 'Hidden rebel camps'],
-            'factions': ['plague_bearers'],
-            'locked': True
-        }
-        
         return hardcoded
     
     def get_regional_bias(self, x: int, y: int) -> str:
@@ -508,54 +362,24 @@ class MorkBorgLoreDatabase:
     def get_regional_npcs(self, region: str) -> List[str]:
         """Get NPCs commonly found in a region."""
         regional_npcs = {
-            'north': [
-                'Undead Knight', 'Ice Witch', 'Frost Giant', 'Tomb Guardian',
-                # NEW: Enhanced with forgotten gods and new content
-                'Bone Crown Archaeologist', 'Old Dead Necromancer', 'Bergen Chrypt Warden',
-                'Ancient King\'s Spirit', 'Frozen Plague Doctor', 'Crypt Robber'
-            ],
-            'central': [
-                'Corrupt Merchant', 'Heretical Priest', 'City Guard', 'Plague Doctor',
-                # NEW: Enhanced with Galgenbeck and tax content
-                'Desperate Tax Collector', 'Soul Contract Negotiator', 'Eager Day Laborer',
-                'Golden Tongue Merchant', 'Ministry Demon', 'Carnival Performer'
-            ],
-            'south': [
-                'Weather Seer', 'Cattle Baron', 'Plague Farmer', 'Stone Circle Keeper',
-                # NEW: Enhanced with Bilkherd cult content
-                'Bilkherd Cattle Cultist', 'Infected Livestock Herder', 'Milk Shrine Keeper',
-                'Sacrificial Cowhand', 'Pastoral Horror Priest', 'Diseased Ranch Owner'
-            ],
-            'west': [
-                'Storm Caller', 'Plague Bearer', 'Desperate Survivor', 'Coastal Raider',
-                # NEW: Enhanced with Becklure and coastal content
-                'Drowned Fisherman', 'Quarantine Warden', 'Becklure Water Cultist',
-                'Plague Ship Captain', 'Lighthouse Keeper', 'Storm Cult Sailor'
-            ],
-            'east': [
-                'Nomad Warrior', 'Caravan Master', 'Desert Oracle', 'Treasure Hunter',
-                # NEW: Enhanced with frontier content
-                'Trade Route Guardian', 'Portal Seeker', 'Calendar Scholar',
-                'Faction Scout', 'Wasteland Guide', 'Resource Flow Merchant'
-            ],
-            'northwest': [
-                'Forest Witch', 'Tree Warden', 'Cursed Druid', 'Beast Speaker',
-                # NEW: Enhanced with Silkfiend and forest content
-                'Silkfiend Artist', 'Web-wrapped Hermit', 'Fate Weaver',
-                'Silk-bound Prisoner', 'Tree-silk Harvester', 'Pattern Reader'
-            ]
+            'north': ['Undead Knight', 'Ice Witch', 'Frost Giant', 'Tomb Guardian'],
+            'central': ['Corrupt Merchant', 'Heretical Priest', 'City Guard', 'Plague Doctor', 'Tax Collector'],
+            'south': ['Weather Seer', 'Cattle Baron', 'Plague Farmer', 'Stone Circle Keeper'],
+            'west': ['Storm Caller', 'Plague Bearer', 'Desperate Survivor', 'Coastal Raider'],
+            'east': ['Nomad Warrior', 'Caravan Master', 'Desert Oracle', 'Treasure Hunter'],
+            'northwest': ['Forest Witch', 'Tree Warden', 'Cursed Druid', 'Beast Speaker']
         }
         return regional_npcs.get(region, ['Wandering Survivor', 'Lost Soul', 'Desperate Scavenger'])
     
     def get_regional_factions(self, region: str) -> List[str]:
         """Get factions active in a region."""
         region_factions = {
-            'north': ['shadow_king_followers', 'heretical_priests', 'old_dead_cult'],
-            'central': ['nechrubel_cult', 'heretical_priests', 'golden_tongue_cult', 'eager_day_laborers'],
-            'south': ['plague_bearers', 'nechrubel_cult', 'bilkherd_cult'],
-            'west': ['plague_bearers', 'becklure_cult'],
+            'north': ['shadow_king_followers', 'heretical_priests'],
+            'central': ['nechrubel_cult', 'heretical_priests'],
+            'south': ['plague_bearers', 'nechrubel_cult'],
+            'west': ['plague_bearers'],
             'east': ['nechrubel_cult'],
-            'northwest': ['forest_witches', 'silkfiend_cult']
+            'northwest': ['forest_witches']
         }
         return region_factions.get(region, ['nechrubel_cult'])
 

--- a/src/mork_borg_lore_database.py
+++ b/src/mork_borg_lore_database.py
@@ -19,7 +19,6 @@ class MorkBorgLoreDatabase:
     def _init_major_cities(self) -> Dict:
         """Initialize major cities from Mörk Borg lore."""
         return {
-            # Core Rulebook Cities
             'galgenbeck': {
                 'name': 'Galgenbeck',
                 'name_pt': 'Galgenbeck',
@@ -33,10 +32,18 @@ class MorkBorgLoreDatabase:
                     'Built on layers of previous cities',
                     'Ruled by mysterious council',
                     'Famous for its hanging gardens of corpses',
-                    'Underground sewers with ancient horrors'
+                    'Underground sewers with ancient horrors',
+                    'Ministry of Wealth & Taxes extracting souls as currency',
+                    'Guild of the Utmost Eager Day Laborers seeking any work',
+                    'House of Binding Contracts where devils broker deals',
+                    'Daily mandatory festivals causing economic standstill',
+                    'Demon infestation in government buildings',
+                    'Silver coin shortage due to ravenous taxation',
+                    'Cult of the Golden Tongue corrupting merchants',
+                    'Heptaliths - seven cursed standing stones in the city center'
                 ],
-                'key_npcs': ['Josilfa Migol', 'The Galgenbeck Council'],
-                'atmosphere': 'Urban decay and ancient evil'
+                'key_npcs': ['Josilfa Migol', 'The Galgenbeck Council', 'Tax Collectors', 'Contract Devils', 'Eager Day Laborers'],
+                'atmosphere': 'Urban decay and ancient evil mixed with bureaucratic horror'
             },
             
             'bergen_chrypt': {
@@ -187,6 +194,68 @@ class MorkBorgLoreDatabase:
                 'regions': ['northwest', 'forest'],
                 'influence': 'magical',
                 'goals': ['Protect ancient secrets', 'Maintain balance', 'Forest preservation']
+            },
+            
+            # NEW: Forgotten Gods Cults (from Ikhon supplement)
+            'bilkherd_cult': {
+                'name': 'Servants of the Bilkherd',
+                'name_pt': 'Servos do Bilkherd',
+                'description': 'Cattle herders and farmers serving the forgotten god of livestock',
+                'description_pt': 'Criadores de gado e fazendeiros servindo o deus esquecido do gado',
+                'regions': ['south', 'central', 'plains'],
+                'influence': 'agricultural',
+                'goals': ['Increase livestock yields', 'Perform cattle sacrifices', 'Spread pastoral corruption']
+            },
+            
+            'becklure_cult': {
+                'name': 'Drowned Servants of the Becklure',
+                'name_pt': 'Servos Afogados do Becklure',
+                'description': 'Fishermen and coastal dwellers serving the water deity',
+                'description_pt': 'Pescadores e moradores costeiros servindo a divindade da água',
+                'regions': ['coast', 'swamp'],
+                'influence': 'maritime',
+                'goals': ['Control waterways', 'Drown the unfaithful', 'Seek sunken treasures']
+            },
+            
+            'old_dead_cult': {
+                'name': 'Whisperers to the Old Dead',
+                'name_pt': 'Sussurradores aos Mortos Antigos',
+                'description': 'Necromancers and grave-robbers serving ancient corpses',
+                'description_pt': 'Necromantes e saqueadores de túmulos servindo cadáveres antigos',
+                'regions': ['north', 'mountain', 'underground'],
+                'influence': 'necromantic',
+                'goals': ['Commune with ancient dead', 'Gather lost knowledge', 'Raise forgotten armies']
+            },
+            
+            'silkfiend_cult': {
+                'name': 'Bound by the Silkfiend',
+                'name_pt': 'Presos pelo Demônio da Seda',
+                'description': 'Artists and craftsmen enslaved by the spider deity',
+                'description_pt': 'Artistas e artesãos escravizados pela divindade aranha',
+                'regions': ['central', 'urban'],
+                'influence': 'artistic',
+                'goals': ['Create cursed artworks', 'Weave fate itself', 'Trap souls in silk']
+            },
+            
+            # NEW: Recent supplement factions
+            'golden_tongue_cult': {
+                'name': 'Cult of the Golden Tongue',
+                'name_pt': 'Culto da Língua Dourada',
+                'description': 'Merchants and tax collectors serving greed incarnate',
+                'description_pt': 'Mercadores e cobradores de impostos servindo a ganância encarnada',
+                'regions': ['central', 'urban'],
+                'influence': 'economic',
+                'goals': ['Accumulate wealth', 'Corrupt through greed', 'Control commerce']
+            },
+            
+            'eager_day_laborers': {
+                'name': 'Guild of the Utmost Eager Day Laborers',
+                'name_pt': 'Guilda dos Mais Ansiosos Trabalhadores Diários',
+                'description': 'Desperate workers performing any task for coin',
+                'description_pt': 'Trabalhadores desesperados realizando qualquer tarefa por moedas',
+                'regions': ['central', 'urban'],
+                'influence': 'labor',
+                'goals': ['Find work at any cost', 'Serve highest bidder', 'Survive another day']
             }
         }
     
@@ -324,6 +393,86 @@ class MorkBorgLoreDatabase:
             'locked': True
         }
         
+        # NEW: Additional special locations from research
+        hardcoded['0812'] = {
+            'type': 'special_location',
+            'name': 'The Weeping Stones',
+            'name_pt': 'As Pedras Chorosas',
+            'terrain': 'plains',
+            'description': 'Ancient standing stones that bleed tears of the innocent',
+            'description_pt': 'Pedras eretas antigas que sangram lágrimas dos inocentes',
+            'atmosphere': 'Ancient sorrow and mystical power',
+            'notable_features': ['Healing tears', 'Attracts undead at night', 'Prophetic visions'],
+            'factions': ['nechrubel_cult', 'shadow_king_followers'],
+            'locked': True
+        }
+        
+        hardcoded['1820'] = {
+            'type': 'special_location',
+            'name': 'Plague Ship Graveyard',
+            'name_pt': 'Cemitério de Navios da Peste',
+            'terrain': 'coast',
+            'description': 'Dozens of diseased vessels run aground on cursed shores',
+            'description_pt': 'Dezenas de navios doentes encalhados em costas amaldiçoadas',
+            'atmosphere': 'Maritime decay and disease',
+            'notable_features': ['Valuable cargo among the dead', 'Plague zombies crew the ships', 'Storm spirits guard the wrecks'],
+            'factions': ['plague_bearers', 'becklure_cult'],
+            'locked': True
+        }
+        
+        hardcoded['0409'] = {
+            'type': 'special_location',
+            'name': 'The Carnival of Sorrows',
+            'name_pt': 'O Carnaval das Tristezas',
+            'terrain': 'plains',  # Mobile, but needs a starting terrain
+            'description': 'Cursed traveling carnival that appears without warning',
+            'description_pt': 'Carnaval amaldiçoado viajante que aparece sem aviso',
+            'atmosphere': 'False joy masking eternal torment',
+            'notable_features': ['Moves every 1d4 weeks', 'Soul gambling games', 'Demonic performers'],
+            'factions': ['silkfiend_cult', 'eager_day_laborers'],
+            'special_properties': ['mobile_location', 'changes_hex_randomly'],
+            'locked': True
+        }
+        
+        hardcoded['2205'] = {
+            'type': 'special_location',
+            'name': 'The Bone Crown Barrows',
+            'name_pt': 'Os Túmulos da Coroa Óssea',
+            'terrain': 'mountain',
+            'description': 'Ancient burial mounds of forgotten kings',
+            'description_pt': 'Montículos funerários antigos de reis esquecidos',
+            'atmosphere': 'Royal death and ancient majesty',
+            'notable_features': ['Crowned skeletons that still rule', 'Treasures beyond imagining', 'Curse upon grave robbers'],
+            'factions': ['old_dead_cult', 'shadow_king_followers'],
+            'locked': True
+        }
+        
+        hardcoded['1618'] = {
+            'type': 'special_location',
+            'name': 'The Ministry of Wealth & Taxes',
+            'name_pt': 'O Ministério da Riqueza e Impostos',
+            'terrain': 'plains',
+            'description': 'Demon-infested government building extracting wealth from souls',
+            'description_pt': 'Prédio governamental infestado de demônios extraindo riqueza das almas',
+            'atmosphere': 'Bureaucratic horror and financial damnation',
+            'notable_features': ['Devils in fine suits', 'Contracts written in blood', 'Vault of stolen souls'],
+            'factions': ['golden_tongue_cult', 'eager_day_laborers'],
+            'locked': True
+        }
+        
+        hardcoded['0722'] = {
+            'type': 'special_location',
+            'name': 'The Quarantine Islands',
+            'name_pt': 'As Ilhas de Quarentena',
+            'terrain': 'coast',
+            'description': 'Isolated islands where plague victims are abandoned',
+            'description_pt': 'Ilhas isoladas onde vítimas da peste são abandonadas',
+            'atmosphere': 'Abandonment and slow death',
+            'notable_features': ['Desperate survivors', 'Mutated plague strains', 'Hidden rebel camps'],
+            'factions': ['plague_bearers'],
+            'locked': True
+        }
+        
         return hardcoded
     
     def get_regional_bias(self, x: int, y: int) -> str:
@@ -359,24 +508,54 @@ class MorkBorgLoreDatabase:
     def get_regional_npcs(self, region: str) -> List[str]:
         """Get NPCs commonly found in a region."""
         regional_npcs = {
-            'north': ['Undead Knight', 'Ice Witch', 'Frost Giant', 'Tomb Guardian'],
-            'central': ['Corrupt Merchant', 'Heretical Priest', 'City Guard', 'Plague Doctor'],
-            'south': ['Weather Seer', 'Cattle Baron', 'Plague Farmer', 'Stone Circle Keeper'],
-            'west': ['Storm Caller', 'Plague Bearer', 'Desperate Survivor', 'Coastal Raider'],
-            'east': ['Nomad Warrior', 'Caravan Master', 'Desert Oracle', 'Treasure Hunter'],
-            'northwest': ['Forest Witch', 'Tree Warden', 'Cursed Druid', 'Beast Speaker']
+            'north': [
+                'Undead Knight', 'Ice Witch', 'Frost Giant', 'Tomb Guardian',
+                # NEW: Enhanced with forgotten gods and new content
+                'Bone Crown Archaeologist', 'Old Dead Necromancer', 'Bergen Chrypt Warden',
+                'Ancient King\'s Spirit', 'Frozen Plague Doctor', 'Crypt Robber'
+            ],
+            'central': [
+                'Corrupt Merchant', 'Heretical Priest', 'City Guard', 'Plague Doctor',
+                # NEW: Enhanced with Galgenbeck and tax content
+                'Desperate Tax Collector', 'Soul Contract Negotiator', 'Eager Day Laborer',
+                'Golden Tongue Merchant', 'Ministry Demon', 'Carnival Performer'
+            ],
+            'south': [
+                'Weather Seer', 'Cattle Baron', 'Plague Farmer', 'Stone Circle Keeper',
+                # NEW: Enhanced with Bilkherd cult content
+                'Bilkherd Cattle Cultist', 'Infected Livestock Herder', 'Milk Shrine Keeper',
+                'Sacrificial Cowhand', 'Pastoral Horror Priest', 'Diseased Ranch Owner'
+            ],
+            'west': [
+                'Storm Caller', 'Plague Bearer', 'Desperate Survivor', 'Coastal Raider',
+                # NEW: Enhanced with Becklure and coastal content
+                'Drowned Fisherman', 'Quarantine Warden', 'Becklure Water Cultist',
+                'Plague Ship Captain', 'Lighthouse Keeper', 'Storm Cult Sailor'
+            ],
+            'east': [
+                'Nomad Warrior', 'Caravan Master', 'Desert Oracle', 'Treasure Hunter',
+                # NEW: Enhanced with frontier content
+                'Trade Route Guardian', 'Portal Seeker', 'Calendar Scholar',
+                'Faction Scout', 'Wasteland Guide', 'Resource Flow Merchant'
+            ],
+            'northwest': [
+                'Forest Witch', 'Tree Warden', 'Cursed Druid', 'Beast Speaker',
+                # NEW: Enhanced with Silkfiend and forest content
+                'Silkfiend Artist', 'Web-wrapped Hermit', 'Fate Weaver',
+                'Silk-bound Prisoner', 'Tree-silk Harvester', 'Pattern Reader'
+            ]
         }
         return regional_npcs.get(region, ['Wandering Survivor', 'Lost Soul', 'Desperate Scavenger'])
     
     def get_regional_factions(self, region: str) -> List[str]:
         """Get factions active in a region."""
         region_factions = {
-            'north': ['shadow_king_followers', 'heretical_priests'],
-            'central': ['nechrubel_cult', 'heretical_priests'],
-            'south': ['plague_bearers', 'nechrubel_cult'],
-            'west': ['plague_bearers'],
+            'north': ['shadow_king_followers', 'heretical_priests', 'old_dead_cult'],
+            'central': ['nechrubel_cult', 'heretical_priests', 'golden_tongue_cult', 'eager_day_laborers'],
+            'south': ['plague_bearers', 'nechrubel_cult', 'bilkherd_cult'],
+            'west': ['plague_bearers', 'becklure_cult'],
             'east': ['nechrubel_cult'],
-            'northwest': ['forest_witches']
+            'northwest': ['forest_witches', 'silkfiend_cult']
         }
         return region_factions.get(region, ['nechrubel_cult'])
 
@@ -395,10 +574,6 @@ def main():
     print(f"\n⚔️ Factions: {len(lore_db.factions)}")
     for faction_key, faction in lore_db.factions.items():
         print(f"  {faction['name']} - {faction['influence']}")
-    
-    print(f"\n🗺️ Hardcoded Hexes: {len(lore_db.hardcoded_hexes)}")
-    for hex_code, data in lore_db.hardcoded_hexes.items():
-        print(f"  {hex_code}: {data['name']} ({data['type']})")
     
     print(f"\n🌍 Regional Biases:")
     for region, data in lore_db.regional_lore.items():

--- a/src/mork_borg_lore_database.py
+++ b/src/mork_borg_lore_database.py
@@ -33,13 +33,27 @@ class MorkBorgLoreDatabase:
                     'Ruled by mysterious council',
                     'Famous for its hanging gardens of corpses',
                     'Underground sewers with ancient horrors',
+                    # From Christian's "Death and Taxes"
                     'Schleswig district with demon infestation',
-                    'Ministry of Wealth & Taxes',
+                    'Ministry of Wealth & Taxes extracting souls as currency',
+                    'Office of the Holy Inquisition (ruined)',
+                    'Cursed Heptaliths throughout the city',
+                    'City (Bone) Mill grinding bones to flour',
                     'Guild of the Utmost Eager Day Laborers',
-                    'House of Binding Contracts'
+                    'House of Binding Contracts for soul trading',
+                    'Cult of the Golden Tongue operating in shadows',
+                    'Mandatory daily festivals causing economic standstill',
+                    # From Christian's "Galgenbeck: Sacrifice"
+                    'Josilfa beheading the unwanted to appease Nechrubel',
+                    'Citizens vanishing from memory when sacrificed',
+                    'Ravens and worse drawn to the stench of corpses',
+                    'Half the population mysteriously gone but unnoticed'
                 ],
-                'key_npcs': ['Josilfa Migol', 'The Galgenbeck Council'],
-                'atmosphere': 'Urban decay and ancient evil'
+                'trade_goods': ['Corpse flowers', 'Bone meal', 'Grave dirt', 'Soul contracts'],
+                'dangers': ['Demon infestation', 'Tax collectors', 'Memory erasure', 'Soul traders'],
+                'ruler': 'Mysterious Council and Josilfa the Sacrificer',
+                'key_npcs': ['Josilfa the Sacrificer', 'The Galgenbeck Council', 'Contract Devils'],
+                'atmosphere': 'Urban decay, sacrifice, and soul trading'
             },
             
             'bergen_chrypt': {
@@ -190,6 +204,48 @@ class MorkBorgLoreDatabase:
                 'regions': ['northwest', 'forest'],
                 'influence': 'magical',
                 'goals': ['Protect ancient secrets', 'Maintain balance', 'Forest preservation']
+            },
+            
+            # From Christian's "Death and Taxes"
+            'eager_day_laborers': {
+                'name': 'Guild of the Utmost Eager Day Laborers',
+                'name_pt': 'Guilda dos Trabalhadores Diários Extremamente Ansiosos',
+                'description': 'Desperate workers seeking any employment in Galgenbeck',
+                'description_pt': 'Trabalhadores desesperados procurando qualquer emprego em Galgenbeck',
+                'regions': ['central'],
+                'influence': 'economic',
+                'goals': ['Find work', 'Survive poverty', 'Serve the wealthy']
+            },
+            
+            'binding_contracts': {
+                'name': 'House of Binding Contracts',
+                'name_pt': 'Casa dos Contratos Vinculativos',
+                'description': 'Soul traders and contract devils operating in Galgenbeck',
+                'description_pt': 'Comerciantes de almas e demônios contratantes operando em Galgenbeck',
+                'regions': ['central'],
+                'influence': 'infernal',
+                'goals': ['Acquire souls', 'Enforce contracts', 'Spread corruption']
+            },
+            
+            'golden_tongue': {
+                'name': 'Cult of the Golden Tongue',
+                'name_pt': 'Culto da Língua Dourada',
+                'description': 'Secret cult obsessed with wealth and golden words',
+                'description_pt': 'Culto secreto obcecado com riqueza e palavras douradas',
+                'regions': ['central'],
+                'influence': 'religious',
+                'goals': ['Hoard gold', 'Speak persuasively', 'Corrupt through greed']
+            },
+            
+            # From Christian's "Bergen Chrypt: Archfrost"
+            'corpse_golem_cults': {
+                'name': 'Corpse Golem Cults',
+                'name_pt': 'Cultos dos Golems de Cadáver',
+                'description': 'Necromantic cults creating undead servants in the mountains',
+                'description_pt': 'Cultos necromânticos criando servos mortos-vivos nas montanhas',
+                'regions': ['north', 'northwest'],
+                'influence': 'necromantic',
+                'goals': ['Raise corpse golems', 'Seek immortality', 'Control the dead']
             }
         }
     
@@ -327,6 +383,25 @@ class MorkBorgLoreDatabase:
             'locked': True
         }
         
+        # Add Bergen Chrypt from Christian's supplement
+        hardcoded['0408'] = {
+            'type': 'special_location',
+            'name': 'Bergen Chrypt',
+            'name_pt': 'Bergen Chrypt',
+            'terrain': 'mountain',
+            'description': 'The most haunted mountain range of the dying lands',
+            'description_pt': 'A cordilheira mais assombrada das terras moribundas',
+            'atmosphere': 'Dark desolation, rifts of unknown make, occult channelers',
+            'features': [
+                'Corpse golem cults',
+                'Unctuous secrets buried in ice',
+                'Rifts of unknown origin',
+                'Occult channelers seeking the Elixir of Life',
+                'Infectious rash upon the skin of the earth'
+            ],
+            'locked': True
+        }
+        
         return hardcoded
     
     def get_regional_bias(self, x: int, y: int) -> str:
@@ -362,14 +437,39 @@ class MorkBorgLoreDatabase:
     def get_regional_npcs(self, region: str) -> List[str]:
         """Get NPCs commonly found in a region."""
         regional_npcs = {
-            'north': ['Undead Knight', 'Ice Witch', 'Frost Giant', 'Tomb Guardian'],
-            'central': ['Corrupt Merchant', 'Heretical Priest', 'City Guard', 'Plague Doctor', 'Tax Collector'],
-            'south': ['Weather Seer', 'Cattle Baron', 'Plague Farmer', 'Stone Circle Keeper'],
-            'west': ['Storm Caller', 'Plague Bearer', 'Desperate Survivor', 'Coastal Raider'],
-            'east': ['Nomad Warrior', 'Caravan Master', 'Desert Oracle', 'Treasure Hunter'],
-            'northwest': ['Forest Witch', 'Tree Warden', 'Cursed Druid', 'Beast Speaker']
+            'north': [
+                'Undead Knight', 'Ice Witch', 'Frost Giant', 'Tomb Guardian',
+                # From Christian's supplements
+                'Corpse Golem Cultist', 'Occult Channeler', 'Bergen Chrypt Explorer'
+            ],
+            'central': [
+                'Corrupt Merchant', 'Heretical Priest', 'City Guard', 'Plague Doctor', 
+                # From Christian's supplements
+                'Desperate Tax Collector', 'Eager Day Laborer', 'Soul Contract Negotiator',
+                'Sacrifice Heretic', 'Golden Tongue Preacher', 'Memory Eraser', 'Bone Mill Worker'
+            ],
+            'south': [
+                'Weather Seer', 'Cattle Baron', 'Plague Farmer', 'Stone Circle Keeper',
+                # From Christian's supplements
+                'Traveling Tax Collector', 'Contract Devil'
+            ],
+            'west': [
+                'Storm Caller', 'Plague Bearer', 'Desperate Survivor', 'Coastal Raider',
+                # From Christian's supplements
+                'Sea Demon', 'Drowned Soul Trader'
+            ],
+            'east': [
+                'Nomad Warrior', 'Caravan Master', 'Desert Oracle', 'Treasure Hunter',
+                # From Christian's supplements
+                'Corpse Golem Hunter', 'Occult Artifact Seeker'
+            ],
+            'northwest': [
+                'Forest Witch', 'Tree Warden', 'Cursed Druid', 'Beast Speaker',
+                # From Christian's supplements
+                'Corpse Golem Cultist', 'Mountain Occult Channeler'
+            ]
         }
-        return regional_npcs.get(region, ['Wandering Survivor', 'Lost Soul', 'Desperate Scavenger'])
+        return regional_npcs.get(region, ['Wandering Scavenger', 'Plague Victim', 'Mad Hermit'])
     
     def get_regional_factions(self, region: str) -> List[str]:
         """Get factions active in a region."""


### PR DESCRIPTION
Add extensive new content to Mörk Borg lore and generation tables.

This integrates recent official content (e.g., Ikhon, Death & Taxes) and expands thematic elements across dungeons, denizens, beasts, loot, and wilderness encounters, based on a prior research document. All additions adhere to existing data structures.