### PR TITLE
Fix city layout map return

### DIFF
--- a/web/templates/main_map.html
+++ b/web/templates/main_map.html
@@ -1922,7 +1922,8 @@ ${data.ascii}
     
     function showCityOverlayInMap(hexCode) {
         // Extract city name from hex code using lore database
-        showMapLoadingState();
+        // Don't call showMapLoadingState() here to preserve original map content
+        // when transitioning from city details to city overlays
         
         // First, get city information to determine the city name
         fetch(`/api/city/${hexCode}`)
@@ -1930,22 +1931,24 @@ ${data.ascii}
             .then(cityData => {
                 if (cityData.success) {
                     const cityName = cityData.city.name.toLowerCase().replace(/\s+/g, '_');
-                    return showCityOverlayGridInMap(cityName, hexCode);
+                    return showCityOverlayGridInMap(cityName, hexCode, false); // Pass false to not save state again
                 } else {
                     // Fallback: try galgenbeck for testing
-                    return showCityOverlayGridInMap('galgenbeck', hexCode);
+                    return showCityOverlayGridInMap('galgenbeck', hexCode, false);
                 }
             })
             .catch(error => {
                 console.error('Error determining city name:', error);
                 // Fallback: try galgenbeck for testing
-                showCityOverlayGridInMap('galgenbeck', hexCode);
+                showCityOverlayGridInMap('galgenbeck', hexCode, false);
             });
     }
     
-    function showCityOverlayGridInMap(overlayName, hexCode) {
-        // Show loading state
-        showMapLoadingState();
+    function showCityOverlayGridInMap(overlayName, hexCode, saveState = true) {
+        // Show loading state only if we need to save the current state
+        if (saveState) {
+            showMapLoadingState();
+        }
         
         fetch(`/api/city-overlay/${overlayName}`, {
             method: 'GET',
@@ -1980,7 +1983,7 @@ ${data.ascii}
                         <div style="text-align: center; padding: 20px; height: 100%; overflow-y: auto;">
                             <div class="mb-4">
                                 <button class="btn btn-mork-borg btn-warning me-2" onclick="showCityDetailsInMap('${hexCode}')">← RETURN TO CITY</button>
-                                <button class="btn btn-mork-borg" onclick="showCityOverlayAsciiInMap('${overlayName}', '${hexCode}')" style="margin-left: 10px;">📜 ASCII VIEW</button>
+                                <button class="btn btn-mork-borg" onclick="showCityOverlayAsciiInMap('${overlayName}', '${hexCode}', false)" style="margin-left: 10px;">📜 ASCII VIEW</button>
                             </div>
                             <div style="background: var(--mork-black); border: 2px solid var(--mork-cyan); padding: 20px; box-shadow: 0 0 20px rgba(0, 255, 255, 0.3);">
                                 <h3 style="color: var(--mork-cyan); margin: 10px 0;">${overlay.display_name}</h3>
@@ -2074,9 +2077,11 @@ ${data.ascii}
             });
     }
     
-    function showCityOverlayAsciiInMap(overlayName, hexCode) {
-        // Show loading state
-        showMapLoadingState();
+    function showCityOverlayAsciiInMap(overlayName, hexCode, saveState = true) {
+        // Show loading state only if we need to save the current state
+        if (saveState) {
+            showMapLoadingState();
+        }
         
         fetch(`/api/city-overlay/${overlayName}/ascii`)
             .then(response => response.json())
@@ -2087,7 +2092,7 @@ ${data.ascii}
                     let html = `
                         <div style="text-align: center; padding: 20px; height: 100%; overflow-y: auto;">
                             <div class="mb-4">
-                                <button class="btn btn-mork-borg btn-warning me-2" onclick="showCityOverlayGridInMap('${overlayName}', '${hexCode}')">← BACK TO GRID</button>
+                                <button class="btn btn-mork-borg btn-warning me-2" onclick="showCityOverlayGridInMap('${overlayName}', '${hexCode}', false)">← BACK TO GRID</button>
                                 <button class="btn btn-mork-borg" onclick="showCityDetailsInMap('${hexCode}')" style="margin-left: 10px;">🏰 RETURN TO CITY</button>
                             </div>
                             <div style="background: var(--mork-black); border: 2px solid var(--mork-cyan); padding: 20px; box-shadow: 0 0 20px rgba(0, 255, 255, 0.3);">

--- a/web/templates/main_map.html
+++ b/web/templates/main_map.html
@@ -739,7 +739,12 @@
     function showMapLoadingState() {
         const mapContainer = document.querySelector('.map-container');
         const originalContent = mapContainer.innerHTML;
-        mapContainer.setAttribute('data-original-content', originalContent);
+        
+        // Only save the original content if it hasn't been saved yet
+        // This prevents overwriting the true original map with intermediate views
+        if (!mapContainer.getAttribute('data-original-content')) {
+            mapContainer.setAttribute('data-original-content', originalContent);
+        }
         
         mapContainer.innerHTML = `
             <div style="text-align: center; padding: 50px; color: var(--mork-cyan);">
@@ -1384,6 +1389,8 @@
         const originalContent = mapContainer.getAttribute('data-original-content');
         if (originalContent) {
             mapContainer.innerHTML = originalContent;
+            // Clear the saved state so future navigations start fresh
+            mapContainer.removeAttribute('data-original-content');
             // Restore hex selection after returning to map
             if (currentHex) {
                 const hexElement = document.querySelector(`[data-hex="${currentHex}"]`);
@@ -1922,8 +1929,7 @@ ${data.ascii}
     
     function showCityOverlayInMap(hexCode) {
         // Extract city name from hex code using lore database
-        // Don't call showMapLoadingState() here to preserve original map content
-        // when transitioning from city details to city overlays
+        showMapLoadingState(); // This will now only save state if not already saved
         
         // First, get city information to determine the city name
         fetch(`/api/city/${hexCode}`)
@@ -1931,24 +1937,22 @@ ${data.ascii}
             .then(cityData => {
                 if (cityData.success) {
                     const cityName = cityData.city.name.toLowerCase().replace(/\s+/g, '_');
-                    return showCityOverlayGridInMap(cityName, hexCode, false); // Pass false to not save state again
+                    return showCityOverlayGridInMap(cityName, hexCode);
                 } else {
                     // Fallback: try galgenbeck for testing
-                    return showCityOverlayGridInMap('galgenbeck', hexCode, false);
+                    return showCityOverlayGridInMap('galgenbeck', hexCode);
                 }
             })
             .catch(error => {
                 console.error('Error determining city name:', error);
                 // Fallback: try galgenbeck for testing
-                showCityOverlayGridInMap('galgenbeck', hexCode, false);
+                showCityOverlayGridInMap('galgenbeck', hexCode);
             });
     }
     
-    function showCityOverlayGridInMap(overlayName, hexCode, saveState = true) {
-        // Show loading state only if we need to save the current state
-        if (saveState) {
-            showMapLoadingState();
-        }
+    function showCityOverlayGridInMap(overlayName, hexCode) {
+        // Show loading state (will only save original content if not already saved)
+        showMapLoadingState();
         
         fetch(`/api/city-overlay/${overlayName}`, {
             method: 'GET',
@@ -1982,8 +1986,9 @@ ${data.ascii}
                     let html = `
                         <div style="text-align: center; padding: 20px; height: 100%; overflow-y: auto;">
                             <div class="mb-4">
+                                <button class="btn btn-mork-borg btn-danger me-2" onclick="restoreMap()">RETURN TO MAP</button>
                                 <button class="btn btn-mork-borg btn-warning me-2" onclick="showCityDetailsInMap('${hexCode}')">← RETURN TO CITY</button>
-                                <button class="btn btn-mork-borg" onclick="showCityOverlayAsciiInMap('${overlayName}', '${hexCode}', false)" style="margin-left: 10px;">📜 ASCII VIEW</button>
+                                <button class="btn btn-mork-borg" onclick="showCityOverlayAsciiInMap('${overlayName}', '${hexCode}')" style="margin-left: 10px;">📜 ASCII VIEW</button>
                             </div>
                             <div style="background: var(--mork-black); border: 2px solid var(--mork-cyan); padding: 20px; box-shadow: 0 0 20px rgba(0, 255, 255, 0.3);">
                                 <h3 style="color: var(--mork-cyan); margin: 10px 0;">${overlay.display_name}</h3>
@@ -2053,6 +2058,7 @@ ${data.ascii}
                 mapContainer.innerHTML = `
                     <div style="text-align: center; padding: 20px; height: 100%; overflow-y: auto;">
                         <div class="mb-4">
+                            <button class="btn btn-mork-borg btn-danger me-2" onclick="restoreMap()">RETURN TO MAP</button>
                             <button class="btn btn-mork-borg btn-warning" onclick="showCityDetailsInMap('${hexCode}')">← RETURN TO CITY</button>
                         </div>
                         <div style="background: var(--mork-black); border: 2px solid var(--mork-red); padding: 20px; box-shadow: 0 0 20px rgba(255, 0, 0, 0.3);">
@@ -2077,11 +2083,9 @@ ${data.ascii}
             });
     }
     
-    function showCityOverlayAsciiInMap(overlayName, hexCode, saveState = true) {
-        // Show loading state only if we need to save the current state
-        if (saveState) {
-            showMapLoadingState();
-        }
+    function showCityOverlayAsciiInMap(overlayName, hexCode) {
+        // Show loading state (will only save original content if not already saved)
+        showMapLoadingState();
         
         fetch(`/api/city-overlay/${overlayName}/ascii`)
             .then(response => response.json())
@@ -2092,7 +2096,8 @@ ${data.ascii}
                     let html = `
                         <div style="text-align: center; padding: 20px; height: 100%; overflow-y: auto;">
                             <div class="mb-4">
-                                <button class="btn btn-mork-borg btn-warning me-2" onclick="showCityOverlayGridInMap('${overlayName}', '${hexCode}', false)">← BACK TO GRID</button>
+                                <button class="btn btn-mork-borg btn-danger me-2" onclick="restoreMap()">RETURN TO MAP</button>
+                                <button class="btn btn-mork-borg btn-warning me-2" onclick="showCityOverlayGridInMap('${overlayName}', '${hexCode}')">← BACK TO GRID</button>
                                 <button class="btn btn-mork-borg" onclick="showCityDetailsInMap('${hexCode}')" style="margin-left: 10px;">🏰 RETURN TO CITY</button>
                             </div>
                             <div style="background: var(--mork-black); border: 2px solid var(--mork-cyan); padding: 20px; box-shadow: 0 0 20px rgba(0, 255, 255, 0.3);">


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fix "Return to Map" button not returning to the world map from city overlay views.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
Previously, navigating from city details to city overlays would overwrite the saved world map content with the city details, causing "Return to Map" to go back to the city details instead of the world map. This PR modifies `showMapLoadingState()` to only save the initial map state once, clears the state upon restoration, and adds "Return to Map" buttons to all city overlay views for direct navigation.

---

**Open Background Agent:** 

[Web](https://www.cursor.com/agents?id=bc-692fc92c-e124-4cf2-95bd-900800b4c470) · [Cursor](https://cursor.com/background-agent?bcId=bc-692fc92c-e124-4cf2-95bd-900800b4c470)