### PR TITLE
Debug portuguese language config issues

### DIFF
--- a/backend/database_manager.py
+++ b/backend/database_manager.py
@@ -128,18 +128,26 @@ class DatabaseManager:
         return tables
     
     def get_table(self, category: str, table_name: str, language: str = 'en') -> List[Any]:
-        """Get a specific table from a category."""
+        """Get a specific table from a category with fallback to English."""
         tables = self.load_tables(language)
         
         # Look in the appropriate category
         category_key = f"{category}_tables"
         if category_key in tables:
-            return tables[category_key].get(table_name, [])
+            result = tables[category_key].get(table_name, [])
+            if result:  # If we found content, return it
+                return result
         
-        # Fallback: search all tables
+        # Fallback: search all tables for the requested language
         for key, table_data in tables.items():
             if isinstance(table_data, dict) and table_name in table_data:
-                return table_data[table_name]
+                result = table_data[table_name]
+                if result:  # If we found content, return it
+                    return result
+        
+        # Final fallback: try English if we're not already using English
+        if language != 'en':
+            return self.get_table(category, table_name, 'en')
         
         return []
     


### PR DESCRIPTION
Implement a fallback to English for missing language database files to resolve content generation issues in Portuguese.

When specific Portuguese database files were missing, the system returned empty lists, causing hex types to be absent and settlements not to open. This change ensures that if a table is not found in the requested language, the system attempts to retrieve it from the English database instead of returning an empty list.

---
<a href="https://cursor.com/background-agent?bcId=bc-b53633f6-a3ec-487e-9b30-af33e2f5c99d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b53633f6-a3ec-487e-9b30-af33e2f5c99d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>